### PR TITLE
Fixes the parsing logic of audio clip, remove unnecessary code in MediaOverlayNode 

### DIFF
--- a/r2-shared-swift/MediaOverlays.swift
+++ b/r2-shared-swift/MediaOverlays.swift
@@ -44,13 +44,13 @@ public class MediaOverlays {
     /// - Returns: The `Clip`, representation of the associated SMIL element.
     /// - Throws: `MediaOverlayNodeError.audio`,
     ///           `MediaOverlayNodeError.timersParsing`.
-    public func clip(forFragmentId id: String) throws -> Clip {
-        let clip: Clip
+    public func clip(forFragmentId id: String) throws -> Clip? {
+        let clip: Clip?
 
         do {
             let fragmentNode = try node(forFragmentId: id)
 
-            clip = try fragmentNode.clip()
+            clip = fragmentNode.clip
         }
         return clip
     }
@@ -68,12 +68,12 @@ public class MediaOverlays {
     ///            one designated by `id`.
     /// - Throws: `MediaOverlayNodeError.audio`,
     ///           `MediaOverlayNodeError.timersParsing`.
-    public func clip(nextAfterFragmentId id: String) throws -> Clip {
-        let clip: Clip
+    public func clip(nextAfterFragmentId id: String) throws -> Clip? {
+        let clip: Clip?
 
         do {
             let fragmentNextNode = try node(nextAfterFragmentId: id)
-            clip = try fragmentNextNode.clip()
+            clip = fragmentNextNode.clip
         }
         return clip
     }


### PR DESCRIPTION
Closes readium/r2-testapp-swift#4

Fixes this crash issue triggered by nil value. Indeed, the nil value is created by inappropriate parsing logic for audio clip inside SMIL file. The purpose this PR is support better parsing logic in [R2Streamer](https://github.com/readium/r2-streamer-swift).

It was using a combined string from R2Streamer with audio URL and begin/end time. Then parse it again to different values here. Maybe, this step is unnecessary. Probably, it's better treating R2Shared as pure entities, and move all the parsing logic to R2Streamer. 