### PR TITLE
Move publication parsing related methods from opds parser to this repo

### DIFF
--- a/r2-shared-swift/Collection.swift
+++ b/r2-shared-swift/Collection.swift
@@ -23,3 +23,49 @@ public class Collection {
         self.name = name
     }
 }
+
+// MARK: - Parsing related errors
+public enum CollectionError: Error {
+    case invalidCollection
+    
+    var localizedDescription: String {
+        switch self {
+        case .invalidCollection:
+            return "Invalid collection"
+        }
+    }
+}
+
+// MARK: - Parsing related methods
+extension Collection {
+    
+    static public func parse(_ collectionDict: [String: Any]) throws -> R2Shared.Collection {
+        guard let name = collectionDict["name"] as? String else {
+            throw CollectionError.invalidCollection
+        }
+        let c = R2Shared.Collection(name: name)
+        for (k, v) in collectionDict {
+            switch k {
+            case "name": // Already handled above
+                continue
+            case "sort_as":
+                c.sortAs = v as? String
+            case "identifier":
+                c.identifier = v as? String
+            case "position":
+                c.position = v as? Double
+            case "links":
+                guard let links = v as? [[String: Any]] else {
+                    throw CollectionError.invalidCollection
+                }
+                for link in links {
+                    c.links.append(try Link.parse(linkDict: link))
+                }
+            default:
+                continue
+            }
+        }
+        return c
+    }
+    
+}

--- a/r2-shared-swift/OPDSProperties/IndirectAcquisition.swift
+++ b/r2-shared-swift/OPDSProperties/IndirectAcquisition.swift
@@ -16,3 +16,37 @@ public class IndirectAcquisition {
         self.typeAcquisition = typeAcquisition
     }
 }
+
+// MARK: - Parsing related errors
+public enum IndirectAcquisitionError: Error {
+    case invalidIndirectAcquisition
+    
+    var localizedDescription: String {
+        switch self {
+        case .invalidIndirectAcquisition:
+            return "Invalid indirect acquisition"
+        }
+    }
+}
+
+// MARK: - Parsing related methods
+extension IndirectAcquisition {
+    
+    static public func parse(indirectAcquisitionDict: [String: Any]) throws -> IndirectAcquisition {
+        guard let iaType = indirectAcquisitionDict["type"] as? String else {
+            throw IndirectAcquisitionError.invalidIndirectAcquisition
+        }
+        let ia = IndirectAcquisition(typeAcquisition: iaType)
+        for (k, v) in indirectAcquisitionDict {
+            if (k == "child") {
+                guard let childDict = v as? [String: Any] else {
+                    throw IndirectAcquisitionError.invalidIndirectAcquisition
+                }
+                let child = try parse(indirectAcquisitionDict: childDict)
+                ia.child.append(child)
+            }
+        }
+        return ia
+    }
+    
+}

--- a/r2-shared-swift/Publication.swift
+++ b/r2-shared-swift/Publication.swift
@@ -272,3 +272,53 @@ public enum ReadiumCSSKey: String {
     
     case publisherFont = "--USER__fontOverride"
 }
+
+// MARK: - Parsing related errors
+public enum PublicationError: Error {
+    case invalidPublication
+    
+    var localizedDescription: String {
+        switch self {
+        case .invalidPublication:
+            return "Invalid publication"
+        }
+    }
+}
+
+// MARK: - Parsing related methods
+extension Publication {
+    
+    static public func parse(pubDict: [String: Any]) throws -> Publication {
+        let p = Publication()
+        for (k, v) in pubDict {
+            switch k {
+            case "metadata":
+                guard let metadataDict = v as? [String: Any] else {
+                    throw PublicationError.invalidPublication
+                }
+                let metadata = try Metadata.parse(metadataDict: metadataDict)
+                p.metadata = metadata
+            case "links":
+                guard let links = v as? [[String: Any]] else {
+                    throw PublicationError.invalidPublication
+                }
+                for linkDict in links {
+                    let link = try Link.parse(linkDict: linkDict)
+                    p.links.append(link)
+                }
+            case "images":
+                guard let links = v as? [[String: Any]] else {
+                    throw PublicationError.invalidPublication
+                }
+                for linkDict in links {
+                    let link = try Link.parse(linkDict: linkDict)
+                    p.images.append(link)
+                }
+            default:
+                continue
+            }
+        }
+        return p
+    }
+    
+}


### PR DESCRIPTION
Fix readium/readium-opds-swift#13 - Must be merge with PR readium/readium-opds-swift#27

This PR adds the publication parsing related methods remove from `OPDS2Parser`.