### PR TITLE
Remove dependency to ObjectMapper to compile with Xcode 10

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "Hearst-DD/ObjectMapper" == 2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "Hearst-DD/ObjectMapper" "2.2.0"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,4 @@ import R2Shared
 
 The project dependencies are managed with [Carthage](https://github.com/Carthage/Carthage). 
 
-Run `carthage update --platform ios` to fetch and build the dependencies:
-
-  - [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper) : ObjectMapper is a framework written in Swift that makes it easy for you to convert your model objects (classes and structs) to (and from JSON, but not used here).
+Run `carthage update --platform ios` to fetch and build the dependencies.

--- a/r2-shared-swift.podspec
+++ b/r2-shared-swift.podspec
@@ -21,6 +21,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/readium/r2-shared-swift.git", :tag => "#{s.version}" }
   s.source_files  = "r2-shared-swift/**/*"
-  s.dependency 'ObjectMapper', '~> 2.2'
 
 end

--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -7,8 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		AEF39DF320E3895200A560F3 /* UserProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF39DF220E3895200A560F3 /* UserProperties.swift */; };
 		57470F7E20ED0D1A000CDCA3 /* DownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57470F7D20ED0D1A000CDCA3 /* DownloadSession.swift */; };
+		AEF39DF320E3895200A560F3 /* UserProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF39DF220E3895200A560F3 /* UserProperties.swift */; };
+		CA6161EF21FB257700D2CFE3 /* R2Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D3F41F4EBE2100DF166D /* R2Shared.framework */; };
+		CA6161F721FB273B00D2CFE3 /* PublicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6161F621FB273B00D2CFE3 /* PublicationTests.swift */; };
+		CA6161FB21FB2B1500D2CFE3 /* ObjectMapper.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CA6161FC21FB2C4400D2CFE3 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */; };
+		CA6161FE21FB47EB00D2CFE3 /* MetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6161FD21FB47EB00D2CFE3 /* MetadataTests.swift */; };
+		CA61620121FB586200D2CFE3 /* ContributorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61620021FB586200D2CFE3 /* ContributorTests.swift */; };
+		CA61621021FB5E4200D2CFE3 /* SubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61620F21FB5E4200D2CFE3 /* SubjectTests.swift */; };
+		CA61621321FB617500D2CFE3 /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61621221FB617500D2CFE3 /* LinkTests.swift */; };
+		CA61621521FB65E000D2CFE3 /* PropertiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61621421FB65E000D2CFE3 /* PropertiesTests.swift */; };
+		CA61621721FB6E8800D2CFE3 /* EncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61621621FB6E8800D2CFE3 /* EncryptionTests.swift */; };
+		CA61621921FB71B300D2CFE3 /* RenditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61621821FB71B300D2CFE3 /* RenditionTests.swift */; };
 		F32314A21F8616C2000FCFB0 /* Drm.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32314A11F8616C2000FCFB0 /* Drm.swift */; };
 		F34CB2891FC56CAD005E3A37 /* DrmLicense.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34CB2881FC56CAD005E3A37 /* DrmLicense.swift */; };
 		F39E9E6F1FC2E1B70098F77E /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */; };
@@ -37,9 +48,43 @@
 		F3F41E1F1FA33AF800F97737 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F41E1E1FA33AF800F97737 /* Collection.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		CA6161F021FB257700D2CFE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F3E7D3EB1F4EBE2100DF166D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F3E7D3F31F4EBE2100DF166D;
+			remoteInfo = "r2-shared-swift";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		CA6161FA21FB2B0B00D2CFE3 /* Copy Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				CA6161FB21FB2B1500D2CFE3 /* ObjectMapper.framework in Copy Frameworks */,
+			);
+			name = "Copy Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		AEF39DF220E3895200A560F3 /* UserProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProperties.swift; sourceTree = "<group>"; };
 		57470F7D20ED0D1A000CDCA3 /* DownloadSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadSession.swift; sourceTree = "<group>"; };
+		AEF39DF220E3895200A560F3 /* UserProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProperties.swift; sourceTree = "<group>"; };
+		CA6161EA21FB257700D2CFE3 /* r2-shared-swiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "r2-shared-swiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA6161EE21FB257700D2CFE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CA6161F621FB273B00D2CFE3 /* PublicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationTests.swift; sourceTree = "<group>"; };
+		CA6161FD21FB47EB00D2CFE3 /* MetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataTests.swift; sourceTree = "<group>"; };
+		CA61620021FB586200D2CFE3 /* ContributorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorTests.swift; sourceTree = "<group>"; };
+		CA61620F21FB5E4200D2CFE3 /* SubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectTests.swift; sourceTree = "<group>"; };
+		CA61621221FB617500D2CFE3 /* LinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkTests.swift; sourceTree = "<group>"; };
+		CA61621421FB65E000D2CFE3 /* PropertiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesTests.swift; sourceTree = "<group>"; };
+		CA61621621FB6E8800D2CFE3 /* EncryptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionTests.swift; sourceTree = "<group>"; };
+		CA61621821FB71B300D2CFE3 /* RenditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenditionTests.swift; sourceTree = "<group>"; };
 		F32314A11F8616C2000FCFB0 /* Drm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drm.swift; sourceTree = "<group>"; };
 		F34CB2881FC56CAD005E3A37 /* DrmLicense.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrmLicense.swift; sourceTree = "<group>"; };
 		F3B1879F1FA33D4D00BB46BF /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
@@ -71,6 +116,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		CA6161E721FB257700D2CFE3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA6161EF21FB257700D2CFE3 /* R2Shared.framework in Frameworks */,
+				CA6161FC21FB2C4400D2CFE3 /* ObjectMapper.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F3E7D3F01F4EBE2100DF166D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -88,6 +142,46 @@
 				57470F7D20ED0D1A000CDCA3 /* DownloadSession.swift */,
 			);
 			path = Toolkit;
+			sourceTree = "<group>";
+		};
+		CA6161EB21FB257700D2CFE3 /* r2-shared-swiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				CA6161F521FB26FA00D2CFE3 /* Publication */,
+				CA6161EE21FB257700D2CFE3 /* Info.plist */,
+			);
+			path = "r2-shared-swiftTests";
+			sourceTree = "<group>";
+		};
+		CA6161F521FB26FA00D2CFE3 /* Publication */ = {
+			isa = PBXGroup;
+			children = (
+				CA61621121FB616A00D2CFE3 /* Link */,
+				CA6161FF21FB585200D2CFE3 /* Metadata */,
+				CA6161F621FB273B00D2CFE3 /* PublicationTests.swift */,
+				CA6161FD21FB47EB00D2CFE3 /* MetadataTests.swift */,
+			);
+			path = Publication;
+			sourceTree = "<group>";
+		};
+		CA6161FF21FB585200D2CFE3 /* Metadata */ = {
+			isa = PBXGroup;
+			children = (
+				CA61620021FB586200D2CFE3 /* ContributorTests.swift */,
+				CA61620F21FB5E4200D2CFE3 /* SubjectTests.swift */,
+			);
+			path = Metadata;
+			sourceTree = "<group>";
+		};
+		CA61621121FB616A00D2CFE3 /* Link */ = {
+			isa = PBXGroup;
+			children = (
+				CA61621221FB617500D2CFE3 /* LinkTests.swift */,
+				CA61621421FB65E000D2CFE3 /* PropertiesTests.swift */,
+				CA61621621FB6E8800D2CFE3 /* EncryptionTests.swift */,
+				CA61621821FB71B300D2CFE3 /* RenditionTests.swift */,
+			);
+			path = Link;
 			sourceTree = "<group>";
 		};
 		F34CB28A1FC5714D005E3A37 /* Drm */ = {
@@ -114,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				F3E7D3F61F4EBE2100DF166D /* r2-shared-swift */,
+				CA6161EB21FB257700D2CFE3 /* r2-shared-swiftTests */,
 				F3E7D3F51F4EBE2100DF166D /* Products */,
 				F3E7D41F1F4ECA9800DF166D /* Frameworks */,
 			);
@@ -123,6 +218,7 @@
 			isa = PBXGroup;
 			children = (
 				F3E7D3F41F4EBE2100DF166D /* R2Shared.framework */,
+				CA6161EA21FB257700D2CFE3 /* r2-shared-swiftTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -220,6 +316,25 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		CA6161E921FB257700D2CFE3 /* r2-shared-swiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA6161F421FB257700D2CFE3 /* Build configuration list for PBXNativeTarget "r2-shared-swiftTests" */;
+			buildPhases = (
+				CA6161E621FB257700D2CFE3 /* Sources */,
+				CA6161E721FB257700D2CFE3 /* Frameworks */,
+				CA6161E821FB257700D2CFE3 /* Resources */,
+				CA6161FA21FB2B0B00D2CFE3 /* Copy Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CA6161F121FB257700D2CFE3 /* PBXTargetDependency */,
+			);
+			name = "r2-shared-swiftTests";
+			productName = "r2-shared-swiftTests";
+			productReference = CA6161EA21FB257700D2CFE3 /* r2-shared-swiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		F3E7D3F31F4EBE2100DF166D /* r2-shared-swift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F3E7D3FC1F4EBE2100DF166D /* Build configuration list for PBXNativeTarget "r2-shared-swift" */;
@@ -244,9 +359,16 @@
 		F3E7D3EB1F4EBE2100DF166D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0940;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = Readium;
 				TargetAttributes = {
+					CA6161E921FB257700D2CFE3 = {
+						CreatedOnToolsVersion = 9.4.1;
+						DevelopmentTeam = WN4T94RAPH;
+						LastSwiftMigration = 0940;
+						ProvisioningStyle = Automatic;
+					};
 					F3E7D3F31F4EBE2100DF166D = {
 						CreatedOnToolsVersion = 8.3.3;
 						LastSwiftMigration = 0930;
@@ -267,11 +389,19 @@
 			projectRoot = "";
 			targets = (
 				F3E7D3F31F4EBE2100DF166D /* r2-shared-swift */,
+				CA6161E921FB257700D2CFE3 /* r2-shared-swiftTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		CA6161E821FB257700D2CFE3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F3E7D3F21F4EBE2100DF166D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -282,6 +412,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		CA6161E621FB257700D2CFE3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA61621021FB5E4200D2CFE3 /* SubjectTests.swift in Sources */,
+				CA61621721FB6E8800D2CFE3 /* EncryptionTests.swift in Sources */,
+				CA6161FE21FB47EB00D2CFE3 /* MetadataTests.swift in Sources */,
+				CA61621521FB65E000D2CFE3 /* PropertiesTests.swift in Sources */,
+				CA61620121FB586200D2CFE3 /* ContributorTests.swift in Sources */,
+				CA61621321FB617500D2CFE3 /* LinkTests.swift in Sources */,
+				CA61621921FB71B300D2CFE3 /* RenditionTests.swift in Sources */,
+				CA6161F721FB273B00D2CFE3 /* PublicationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F3E7D3EF1F4EBE2100DF166D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -317,7 +462,66 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		CA6161F121FB257700D2CFE3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F3E7D3F31F4EBE2100DF166D /* r2-shared-swift */;
+			targetProxy = CA6161F021FB257700D2CFE3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		CA6161F221FB257700D2CFE3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WN4T94RAPH;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "r2-shared-swiftTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.readium.r2-shared-swiftTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CA6161F321FB257700D2CFE3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WN4T94RAPH;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "r2-shared-swiftTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.readium.r2-shared-swiftTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		F3E7D3FA1F4EBE2100DF166D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -501,6 +705,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		CA6161F421FB257700D2CFE3 /* Build configuration list for PBXNativeTarget "r2-shared-swiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA6161F221FB257700D2CFE3 /* Debug */,
+				CA6161F321FB257700D2CFE3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F3E7D3EE1F4EBE2100DF166D /* Build configuration list for PBXProject "r2-shared-swift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -9,10 +9,10 @@
 /* Begin PBXBuildFile section */
 		57470F7E20ED0D1A000CDCA3 /* DownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57470F7D20ED0D1A000CDCA3 /* DownloadSession.swift */; };
 		AEF39DF320E3895200A560F3 /* UserProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF39DF220E3895200A560F3 /* UserProperties.swift */; };
+		CA40C07621FF1BA70069A50E /* MultilangStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA40C07521FF1BA70069A50E /* MultilangStringTests.swift */; };
+		CA40C07A21FF25F80069A50E /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA40C07921FF25F80069A50E /* JSON.swift */; };
 		CA6161EF21FB257700D2CFE3 /* R2Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D3F41F4EBE2100DF166D /* R2Shared.framework */; };
 		CA6161F721FB273B00D2CFE3 /* PublicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6161F621FB273B00D2CFE3 /* PublicationTests.swift */; };
-		CA6161FB21FB2B1500D2CFE3 /* ObjectMapper.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		CA6161FC21FB2C4400D2CFE3 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */; };
 		CA6161FE21FB47EB00D2CFE3 /* MetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6161FD21FB47EB00D2CFE3 /* MetadataTests.swift */; };
 		CA61620121FB586200D2CFE3 /* ContributorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61620021FB586200D2CFE3 /* ContributorTests.swift */; };
 		CA61621021FB5E4200D2CFE3 /* SubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61620F21FB5E4200D2CFE3 /* SubjectTests.swift */; };
@@ -22,7 +22,6 @@
 		CA61621921FB71B300D2CFE3 /* RenditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61621821FB71B300D2CFE3 /* RenditionTests.swift */; };
 		F32314A21F8616C2000FCFB0 /* Drm.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32314A11F8616C2000FCFB0 /* Drm.swift */; };
 		F34CB2891FC56CAD005E3A37 /* DrmLicense.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34CB2881FC56CAD005E3A37 /* DrmLicense.swift */; };
-		F39E9E6F1FC2E1B70098F77E /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */; };
 		F3B187A01FA33D4D00BB46BF /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B1879F1FA33D4D00BB46BF /* Feed.swift */; };
 		F3B187A21FA33DFA00BB46BF /* Facet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B187A11FA33DFA00BB46BF /* Facet.swift */; };
 		F3B187A41FA33E1D00BB46BF /* OpdsMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B187A31FA33E1D00BB46BF /* OpdsMetadata.swift */; };
@@ -65,7 +64,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				CA6161FB21FB2B1500D2CFE3 /* ObjectMapper.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -75,6 +73,8 @@
 /* Begin PBXFileReference section */
 		57470F7D20ED0D1A000CDCA3 /* DownloadSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadSession.swift; sourceTree = "<group>"; };
 		AEF39DF220E3895200A560F3 /* UserProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProperties.swift; sourceTree = "<group>"; };
+		CA40C07521FF1BA70069A50E /* MultilangStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilangStringTests.swift; sourceTree = "<group>"; };
+		CA40C07921FF25F80069A50E /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		CA6161EA21FB257700D2CFE3 /* r2-shared-swiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "r2-shared-swiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA6161EE21FB257700D2CFE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA6161F621FB273B00D2CFE3 /* PublicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationTests.swift; sourceTree = "<group>"; };
@@ -107,7 +107,6 @@
 		F3E7D40B1F4EC69100DF166D /* Rendition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Rendition.swift; sourceTree = "<group>"; };
 		F3E7D40C1F4EC69100DF166D /* RootFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootFile.swift; sourceTree = "<group>"; };
 		F3E7D40D1F4EC69100DF166D /* Subject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subject.swift; sourceTree = "<group>"; };
-		F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ObjectMapper.framework; path = Carthage/Build/iOS/ObjectMapper.framework; sourceTree = "<group>"; };
 		F3E7D4221F4ECB3D00DF166D /* ISO8601DateString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ISO8601DateString.swift; sourceTree = "<group>"; };
 		F3F41E171FA3377E00F97737 /* Price.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Price.swift; sourceTree = "<group>"; };
 		F3F41E191FA3378900F97737 /* IndirectAcquisition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndirectAcquisition.swift; sourceTree = "<group>"; };
@@ -121,7 +120,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA6161EF21FB257700D2CFE3 /* R2Shared.framework in Frameworks */,
-				CA6161FC21FB2C4400D2CFE3 /* ObjectMapper.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -129,7 +127,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F39E9E6F1FC2E1B70098F77E /* ObjectMapper.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -147,6 +144,7 @@
 		CA6161EB21FB257700D2CFE3 /* r2-shared-swiftTests */ = {
 			isa = PBXGroup;
 			children = (
+				CA40C07921FF25F80069A50E /* JSON.swift */,
 				CA6161F521FB26FA00D2CFE3 /* Publication */,
 				CA6161EE21FB257700D2CFE3 /* Info.plist */,
 			);
@@ -169,6 +167,7 @@
 			children = (
 				CA61620021FB586200D2CFE3 /* ContributorTests.swift */,
 				CA61620F21FB5E4200D2CFE3 /* SubjectTests.swift */,
+				CA40C07521FF1BA70069A50E /* MultilangStringTests.swift */,
 			);
 			path = Metadata;
 			sourceTree = "<group>";
@@ -288,7 +287,6 @@
 		F3E7D41F1F4ECA9800DF166D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F3E7D4201F4ECA9800DF166D /* ObjectMapper.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -417,6 +415,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA61621021FB5E4200D2CFE3 /* SubjectTests.swift in Sources */,
+				CA40C07A21FF25F80069A50E /* JSON.swift in Sources */,
 				CA61621721FB6E8800D2CFE3 /* EncryptionTests.swift in Sources */,
 				CA6161FE21FB47EB00D2CFE3 /* MetadataTests.swift in Sources */,
 				CA61621521FB65E000D2CFE3 /* PropertiesTests.swift in Sources */,
@@ -424,6 +423,7 @@
 				CA61621321FB617500D2CFE3 /* LinkTests.swift in Sources */,
 				CA61621921FB71B300D2CFE3 /* RenditionTests.swift in Sources */,
 				CA6161F721FB273B00D2CFE3 /* PublicationTests.swift in Sources */,
+				CA40C07621FF1BA70069A50E /* MultilangStringTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/r2-shared-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/r2-shared-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/r2-shared-swift/Contributor.swift
+++ b/r2-shared-swift/Contributor.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// Generated from <dc:contributor>.
 /// An entity responsible for making contributions to the resource.
@@ -32,26 +31,27 @@ public class Contributor {
 
     public init() {}
 
-    public required init?(map: Map) {}
-
 }
-extension Contributor: Mappable {
-    /// JSON Serialisation function.
-    public func mapping(map: Map) {
-        // If multiString is not empty, then serialize it.
-        if !multilangName.multiString.isEmpty {
-            multilangName.multiString <- map["name"]
-        } else {
-            var nameForSinglestring = multilangName.singleString ?? ""
 
-            nameForSinglestring <- map["name"]
-        }
-        sortAs <- map["sortAs", ignoreNil: true]
-        identifier <- map["identifier", ignoreNil: true]
-        if !roles.isEmpty {
-            roles <- map["roles", ignoreNil: true]
-        }
+extension Contributor: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case sortAs
+        case identifier
+        case roles
     }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(identifier, forKey: .identifier)
+        try container.encode(multilangName, forKey: .name)
+        if !roles.isEmpty {
+            try container.encode(roles, forKey: .roles)
+        }
+        try container.encodeIfPresent(sortAs, forKey: .sortAs)
+    }
+    
 }
 
 // MARK: - Parsing related errors

--- a/r2-shared-swift/Encryption.swift
+++ b/r2-shared-swift/Encryption.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 /// Contains metadata parsed from Encryption.xml.
-public struct Encryption {
+public struct Encryption: Encodable {
     /// Identifies the algorithm used to encrypt the resource.
     public var algorithm: String?
     /// Compression method used on the resource.
@@ -25,10 +25,7 @@ public struct Encryption {
     public var scheme: String?
 
     public init() {}
-}
 
-extension Encryption: Encodable {
-    
     enum CodingKeys: String, CodingKey {
         case algorithm
         case compression

--- a/r2-shared-swift/Encryption.swift
+++ b/r2-shared-swift/Encryption.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// Contains metadata parsed from Encryption.xml.
 public struct Encryption {
@@ -28,14 +27,14 @@ public struct Encryption {
     public init() {}
 }
 
-extension Encryption: Mappable {
-    public init?(map: Map) {}
-
-    public mutating func mapping(map: Map) {
-        algorithm <- map["algorithm", ignoreNil: true]
-        compression <- map["compression", ignoreNil: true]
-        originalLength <- map["originalLength", ignoreNil: true]
-        profile <- map["profile", ignoreNil: true]
-        scheme <- map["scheme", ignoreNil: true]
+extension Encryption: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case algorithm
+        case compression
+        case originalLength
+        case profile
+        case scheme
     }
+
 }

--- a/r2-shared-swift/Link.swift
+++ b/r2-shared-swift/Link.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// A Link to a resource.
 public class Link {
@@ -44,8 +43,6 @@ public class Link {
 
     public init() {}
 
-    public required init?(map: Map) {}
-
     /// Check wether a link's resource is encrypted by checking is 
     /// properties.encrypted is set.
     ///
@@ -58,21 +55,35 @@ public class Link {
     }
 }
 
-extension Link: Mappable {
-    public func mapping(map: Map) {
-        href <- map["href", ignoreNil: true]
-        typeLink <- map["type", ignoreNil: true]
-        if !rel.isEmpty {
-            rel <- map["rel", ignoreNil: true]
-        }
-        height <- map["height", ignoreNil: true]
-        width <- map["width", ignoreNil: true]
-        duration <- map["duration", ignoreNil: true]
-        title <- map["title", ignoreNil: true]
-        if !properties.isEmpty() {
-            properties <- map["properties", ignoreNil: true]
-        }
+extension Link: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case duration
+        case height
+        case href
+        case properties
+        case rel
+        case title
+        case type
+        case width
     }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(duration, forKey: .duration)
+        try container.encodeIfPresent(height, forKey: .height)
+        try container.encodeIfPresent(href, forKey: .href)
+        if !properties.isEmpty() {
+            try container.encodeIfPresent(properties, forKey: .properties)
+        }
+        if !rel.isEmpty {
+            try container.encode(rel, forKey: .rel)
+        }
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(typeLink, forKey: .type)
+        try container.encodeIfPresent(width, forKey: .width)
+    }
+    
 }
 
 // MARK: - Parsing related errors

--- a/r2-shared-swift/MediaOverlays.swift
+++ b/r2-shared-swift/MediaOverlays.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import ObjectMapper
 
 
 /// Errors related to MediaOverlays.

--- a/r2-shared-swift/Metadata.swift
+++ b/r2-shared-swift/Metadata.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// The data representation of the <metadata> element of the ".opf" file.
 public class Metadata {
@@ -137,10 +136,6 @@ public class Metadata {
     public init() {
         direction = .Default
     }
-
-    required public init?(map: Map) {
-        direction = .Default
-    }
     
     /// Get the title for the given `lang`, if it exists in the dictionnary.
     ///
@@ -156,80 +151,96 @@ public class Metadata {
 }
 
 // JSON Serialisation extension.
-extension Metadata: Mappable {
-    public func mapping(map: Map) {
-        var modified = self.modified?.iso8601
-
-        identifier <- map["identifier", ignoreNil: true]
-        // If multiString is not empty, then serialize it.
-        if var titlesFromMultistring = multilangTitle?.multiString,
-            !titlesFromMultistring.isEmpty {
-            titlesFromMultistring <- map["title"]
-        } else {
-            var titleForSinglestring = multilangTitle?.singleString ?? ""
-
-            titleForSinglestring <- map["title"]
-        }
-        
-        if var subtitlesFromMultistring = multilangTitle?.multiString,
-            !subtitlesFromMultistring.isEmpty {
-            subtitlesFromMultistring <- map["subtitle"]
-        } else {
-            var subtitleForSinglestring = multilangTitle?.singleString ?? ""
-            subtitleForSinglestring <- map["subtitle"]
-        }
-        
-        languages <- map["languages", ignoreNil: true]
-        if !authors.isEmpty {
-            authors <- map["authors", ignoreNil: true]
-        }
-        if !translators.isEmpty {
-            translators <- map["translators", ignoreNil: true]
-        }
-        if !editors.isEmpty {
-            editors <- map["editors", ignoreNil: true]
-        }
+extension Metadata: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case artists
+        case authors
+        case colorists
+        case contributors
+        case identifier
+        case illustrators
+        case imprints
+        case inkers
+        case editors
+        case languages
+        case letterers
+        case modified
+        case narrators
+        case pencilers
+        case published
+        case publishers
+        case rendition
+        case rights
+        case source
+        case subjects
+        case subtitle
+        case title
+        case translators
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
         if !artists.isEmpty {
-            artists <- map["artists", ignoreNil: true]
+            try container.encode(artists, forKey: .artists)
         }
-        if !illustrators.isEmpty {
-            illustrators <- map["illustrators", ignoreNil: true]
-        }
-        if !letterers.isEmpty {
-            letterers <- map["letterers", ignoreNil: true]
-        }
-        if !pencilers.isEmpty {
-            pencilers <- map["pencilers", ignoreNil: true]
+        if !authors.isEmpty {
+            try container.encode(authors, forKey: .authors)
         }
         if !colorists.isEmpty {
-            colorists <- map["colorists", ignoreNil: true]
-        }
-        if !inkers.isEmpty {
-            inkers <- map["inkers", ignoreNil: true]
-        }
-        if !narrators.isEmpty {
-            narrators <- map["narrators", ignoreNil: true]
+            try container.encode(colorists, forKey: .colorists)
         }
         if !contributors.isEmpty {
-            contributors <- map["contributors", ignoreNil: true]
+            try container.encode(contributors, forKey: .contributors)
         }
-        if !publishers.isEmpty {
-            publishers <- map["publishers", ignoreNil: true]
+        try container.encodeIfPresent(identifier, forKey: .identifier)
+        if !illustrators.isEmpty {
+            try container.encode(illustrators, forKey: .illustrators)
         }
         if !imprints.isEmpty {
-            imprints <- map["imprints", ignoreNil: true]
+            try container.encode(imprints, forKey: .imprints)
         }
-        modified <- map["modified", ignoreNil: true]
-        published <- map["published", ignoreNil: true]
+        if !inkers.isEmpty {
+            try container.encode(inkers, forKey: .inkers)
+        }
+        if !editors.isEmpty {
+            try container.encode(editors, forKey: .editors)
+        }
+        try container.encode(languages, forKey: .languages)
+        if !letterers.isEmpty {
+            try container.encode(letterers, forKey: .letterers)
+        }
+        try container.encodeIfPresent(modified?.iso8601, forKey: .modified)
+        if !narrators.isEmpty {
+            try container.encode(narrators, forKey: .narrators)
+        }
+        if !pencilers.isEmpty {
+            try container.encode(pencilers, forKey: .pencilers)
+        }
+        try container.encodeIfPresent(published, forKey: .published)
+        if !publishers.isEmpty {
+            try container.encode(publishers, forKey: .publishers)
+        }
         if !rendition.isEmpty() {
-            rendition <- map["rendition", ignoreNil: true]
+            try container.encode(rendition, forKey: .rendition)
         }
-        source <- map["source", ignoreNil: true]
-        rights <- map["rights", ignoreNil: true]
+        try container.encodeIfPresent(rights, forKey: .rights)
+        try container.encodeIfPresent(source, forKey: .source)
         if !subjects.isEmpty {
-            subjects <- map["subjects", ignoreNil: true]
+            try container.encode(subjects, forKey: .subjects)
+        }
+        try container.encodeIfPresent(multilangSubtitle, forKey: .subtitle)
+        // title is required (https://readium.org/webpub-manifest/schema/extensions/epub/metadata.schema.json)
+        if let multilangTitle = multilangTitle {
+            try container.encode(multilangTitle, forKey: .title)
+        } else {
+            try container.encode("", forKey: .title)
+        }
+        if !translators.isEmpty {
+            try container.encode(translators, forKey: .translators)
         }
     }
+    
 }
 
 public enum PageProgressionDirection: String {

--- a/r2-shared-swift/MultilangString.swift
+++ b/r2-shared-swift/MultilangString.swift
@@ -25,3 +25,16 @@ public class MultilangString {
 
     public init() {}
 }
+
+extension MultilangString: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        if multiString.isEmpty {
+            try container.encode(singleString ?? "")
+        } else {
+            try container.encode(multiString)
+        }
+    }
+    
+}

--- a/r2-shared-swift/Properties.swift
+++ b/r2-shared-swift/Properties.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// Properties object used for `Link`s properties.
 public struct Properties {
@@ -42,12 +41,7 @@ public struct Properties {
     public var indirectAcquisition: [IndirectAcquisition]?
 
     public init() {}
-}
-
-extension Properties: Mappable {
-
-    public init?(map: Map) {}
-
+    
     /// Return a Boolean indicating wether the property contains informations or
     /// not.
     ///
@@ -61,18 +55,35 @@ extension Properties: Mappable {
         }
         return false
     }
+    
+}
 
-    /// JSON mapping utility function.
-    public mutating func mapping(map: Map) {
+
+extension Properties: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case contains
+        case encryption
+        case layout
+        case mediaOverlay
+        case orientation
+        case overflow
+        case page
+        case spread
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
         if !contains.isEmpty {
-            contains <- map["contains", ignoreNil: true]
+            try container.encode(contains, forKey: .contains)
         }
-        mediaOverlay <- map["mediaOverlay", ignoreNil: true]
-        encryption <- map["encryption", ignoreNil: true]
-        layout <- map["layout", ignoreNil: true]
-        orientation <- map["orientation", ignoreNil: true]
-        overflow <- map["overflow", ignoreNil: true]
-        page <- map["page", ignoreNil: true]
-        spread <- map["spread", ignoreNil: true]
-    }    
+        try container.encodeIfPresent(encryption, forKey: .encryption)
+        try container.encodeIfPresent(layout, forKey: .layout)
+        try container.encodeIfPresent(mediaOverlay, forKey: .mediaOverlay)
+        try container.encodeIfPresent(orientation, forKey: .orientation)
+        try container.encodeIfPresent(overflow, forKey: .overflow)
+        try container.encodeIfPresent(page, forKey: .page)
+        try container.encodeIfPresent(spread, forKey: .spread)
+    }
+        
 }

--- a/r2-shared-swift/Publication.swift
+++ b/r2-shared-swift/Publication.swift
@@ -10,12 +10,11 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// The representation of EPUB publication, with its metadata, its spine and 
 /// other resources.
 /// It is created by the `EpubParser` from an EPUB file or directory.
-/// As it is extended by `Mappable`, it can be serialized to `JSON`.
+/// As it extends `Encodable`, it can be serialized to `JSON`.
 public class Publication {
     /// The version of the publication, if the type needs any.
     public var version: Double
@@ -88,38 +87,52 @@ public class Publication {
     /// Return the serialized JSON for the Publication object: the WebPubManifest
     /// (canonical).
     public var manifest: String {
-        var jsonString = self.toJSONString(prettyPrint: true) ?? ""
-
-        jsonString = jsonString.replacingOccurrences(of: "\\", with: "")
-        return jsonString
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting.insert(.prettyPrinted);
+        
+        guard let jsonData = try? jsonEncoder.encode(self),
+            let json = String(data: jsonData, encoding: .utf8)
+            else {
+                return "{}"
+        }
+        
+        // Unescape slashes
+        return json.replacingOccurrences(of: "\\/", with: "/")
     }
 
     public var manifestCanonical: String {
-        // Not needed so far.
-        let canonicalPublication = self
-
-        // Remove links.
-        canonicalPublication.links = []
+        var manifest = manifestDictionnary
+        // Remove links from the canonical manifest
+        manifest.removeValue(forKey: CodingKeys.links.rawValue)
         
-        var jsonString = canonicalPublication.toJSONString(prettyPrint: false) ?? ""
-
-        jsonString = jsonString.replacingOccurrences(of: "\\", with: "")
-        return jsonString
+        var options = JSONSerialization.WritingOptions()
+        if #available(iOS 11.0, *) {
+            options.insert(.sortedKeys)
+        }
         
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: manifest, options: options),
+            let json = String(data: jsonData, encoding: .utf8)
+            else {
+                return "{}"
+        }
+        
+        // Unescape slashes
+        return json.replacingOccurrences(of: "\\/", with: "/")
     }
 
     /// Returns the JSON dictionnary.
     public var manifestDictionnary: [String: Any] {
-        return self.toJSON()
+        guard let jsonData = try? JSONEncoder().encode(self),
+              let manifestDict = try? JSONSerialization.jsonObject(with: jsonData),
+              let manifest = manifestDict as? [String: Any]
+        else {
+            return [:]
+        }
+        
+        return manifest
     }
 
     public init() {
-        version = 0.0
-        metadata = Metadata()
-    }
-
-    /// Mappable JSON protocol initializer
-    required public init?(map: Map) {
         version = 0.0
         metadata = Metadata()
     }
@@ -228,36 +241,49 @@ public class Publication {
     }
 }
 
-extension Publication: Mappable {
-
-    /// Mapping declaration
-    public func mapping(map: Map) {
-        metadata <- map["metadata", ignoreNil: true]
-        if !links.isEmpty {
-            links <- map["links", ignoreNil: true]
-        }
-        if !spine.isEmpty {
-            spine <- map["spine", ignoreNil: true]
-        }
-        if !resources.isEmpty {
-            resources <- map["resources", ignoreNil: true]
-        }
-        if !tableOfContents.isEmpty {
-            tableOfContents <- map["toc", ignoreNil: true]
-        }
-        if !pageList.isEmpty {
-            pageList <- map["page-list", ignoreNil: true]
-        }
+extension Publication: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case landmarks
+        case links
+        case listOfIllustrations = "loi"
+        case listOfTables = "lot"
+        case metadata
+        case pageList = "page-list"
+        case resources
+        case spine
+        case tableOfContents = "toc"
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
         if !landmarks.isEmpty {
-            landmarks <- map["landmarks", ignoreNil: true]
+            try container.encode(landmarks, forKey: .landmarks)
+        }
+        if !links.isEmpty {
+            try container.encode(links, forKey: .links)
         }
         if !listOfIllustrations.isEmpty {
-            listOfIllustrations <- map["loi", ignoreNil: true]
+            try container.encode(listOfIllustrations, forKey: .listOfIllustrations)
         }
         if !listOfTables.isEmpty {
-            listOfTables <- map["lot", ignoreNil: true]
+            try container.encode(listOfTables, forKey: .listOfTables)
+        }
+        try container.encode(metadata, forKey: .metadata)
+        if !pageList.isEmpty {
+            try container.encode(pageList, forKey: .pageList)
+        }
+        if !resources.isEmpty {
+            try container.encode(resources, forKey: .resources)
+        }
+        if !spine.isEmpty {
+            try container.encode(spine, forKey: .spine)
+        }
+        if !tableOfContents.isEmpty {
+            try container.encode(tableOfContents, forKey: .tableOfContents)
         }
     }
+
 }
 
 /// List of strings that can identify a user setting

--- a/r2-shared-swift/Publication.swift
+++ b/r2-shared-swift/Publication.swift
@@ -15,7 +15,7 @@ import ObjectMapper
 /// The representation of EPUB publication, with its metadata, its spine and 
 /// other resources.
 /// It is created by the `EpubParser` from an EPUB file or directory.
-/// As it is extended by `Mappable`, it can be deserialized to `JSON`.
+/// As it is extended by `Mappable`, it can be serialized to `JSON`.
 public class Publication {
     /// The version of the publication, if the type needs any.
     public var version: Double

--- a/r2-shared-swift/Rendition.swift
+++ b/r2-shared-swift/Rendition.swift
@@ -10,13 +10,12 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// The rendition layout property of an EPUB publication
 ///
 /// - Reflowable: Apply dynamic pagination when rendering.
 /// - Fixed: Fixed layout.
-public enum RenditionLayout: String {
+public enum RenditionLayout: String, Encodable {
     case reflowable = "reflowable"
     case fixed = "pre-paginated"
 }
@@ -31,7 +30,7 @@ public enum RenditionLayout: String {
 ///             overflow content, and each spine item with this property is to 
 ///             be rendered as separate scrollable document.
 /// - Fixed:
-public enum RenditionFlow: String {
+public enum RenditionFlow: String, Encodable {
     case paginated = "paginated"
     case continuous = "continuous"
     case document = "document"
@@ -46,7 +45,7 @@ public enum RenditionFlow: String {
 ///              landscape orientation.
 /// - Portrait: Specifies that the given spine item is to be rendered in portrait
 ///             orientation.
-public enum RenditionOrientation: String {
+public enum RenditionOrientation: String, Encodable {
     case auto = "auto"
     case landscape = "landscape"
     case portrait = "portrait"
@@ -64,7 +63,7 @@ public enum RenditionOrientation: String {
 ///         spine item in both portrait and landscape orientations.
 /// - none: Specifies the Reading System should not render a synthetic spread 
 ///         for the spine item.
-public enum RenditionSpread: String {
+public enum RenditionSpread: String, Encodable {
     case auto = "auto"
     case landscape = "landscape"
     case portrait = "portrait"
@@ -89,8 +88,6 @@ public class Rendition {
 
     public init() {}
 
-    required public init?(map: Map) {}
-
     public func isEmpty() -> Bool {
         guard layout != nil || flow != nil
             || orientation != nil || spread != nil
@@ -103,12 +100,14 @@ public class Rendition {
 
 }
 
-extension Rendition: Mappable {
-    public func mapping(map: Map) {
-        layout <- map["layout", ignoreNil: true]
-        flow <- map["flow", ignoreNil: true]
-        orientation <- map["orientation", ignoreNil: true]
-        spread <- map["spread", ignoreNil: true]
-        viewport <- map["viewport", ignoreNil: true]
+extension Rendition: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case layout
+        case flow
+        case orientation
+        case spread
+        case viewport
     }
+    
 }

--- a/r2-shared-swift/Rendition.swift
+++ b/r2-shared-swift/Rendition.swift
@@ -74,7 +74,7 @@ public enum RenditionSpread: String, Encodable {
 /// The information relative to the rendering of the publication.
 /// It includes if it's reflowable or pre-paginated, the orientation, the synthetic spread
 /// behaviour and if the content flow should be scrolled, continuous or paginated.
-public class Rendition {
+public class Rendition: Encodable {
     /// The rendition layout (reflowable or fixed).
     public var layout: RenditionLayout?
     /// The rendition flow.
@@ -97,10 +97,6 @@ public class Rendition {
         }
         return false
     }
-
-}
-
-extension Rendition: Encodable {
     
     enum CodingKeys: String, CodingKey {
         case layout

--- a/r2-shared-swift/Subject.swift
+++ b/r2-shared-swift/Subject.swift
@@ -15,7 +15,7 @@ import Foundation
 /// https://github.com/readium/webpub-manifest/blob/master/contexts/default/definitions.md#subjects
 /// Epub 3.1
 /// http://www.idpf.org/epub/31/spec/epub-packages.html#sec-opf-dcsubject
-public class Subject {
+public class Subject: Encodable {
     public var name: String?
     /// The WebPubManifest elements
     public var sortAs: String?
@@ -27,10 +27,6 @@ public class Subject {
     public var links = [Link]()
     
     public init() {}
-    
-}
-
-extension Subject: Encodable {
     
     enum CodingKeys: String, CodingKey {
         case name

--- a/r2-shared-swift/Subject.swift
+++ b/r2-shared-swift/Subject.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import ObjectMapper
 
 /// WebPub manifest spec
 /// https://github.com/readium/webpub-manifest/blob/master/contexts/default/definitions.md#subjects
@@ -29,14 +28,15 @@ public class Subject {
     
     public init() {}
     
-    public required init?(map: Map) {}
 }
 
-extension Subject: Mappable {
-    public func mapping(map: Map) {
-        name <- map["name", ignoreNil: true]
-        sortAs <- map["sortAs", ignoreNil: true]
-        scheme <- map["scheme", ignoreNil: true]
-        code <- map["code", ignoreNil: true]
+extension Subject: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case sortAs
+        case scheme
+        case code
     }
+    
 }

--- a/r2-shared-swiftTests/Info.plist
+++ b/r2-shared-swiftTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/r2-shared-swiftTests/JSON.swift
+++ b/r2-shared-swiftTests/JSON.swift
@@ -1,0 +1,22 @@
+//
+//  Created by Mickaël Menu on 28.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import Foundation
+
+func toJSON<T: Encodable>(_ object: T) -> String? {
+    let jsonEncoder = JSONEncoder()
+    jsonEncoder.outputFormatting.insert(.sortedKeys)
+    guard let jsonData = try? jsonEncoder.encode(object),
+        let json = String(data: jsonData, encoding: .utf8)
+        else {
+            return "{}"
+    }
+    
+    return json
+}

--- a/r2-shared-swiftTests/Publication/Link/EncryptionTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/EncryptionTests.swift
@@ -7,15 +7,10 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class EncryptionTests: XCTestCase {
-    
-    func toJSON(_ publication: Encryption) -> String? {
-        return Mapper().toJSONString(publication)
-    }
     
     func testEmptyJSONSerialization() {
         let sut = Encryption()
@@ -34,7 +29,7 @@ class EncryptionTests: XCTestCase {
         sut.scheme = "http://scheme"
 
         XCTAssertEqual(toJSON(sut), """
-            {"profile":"http:\\/\\/profile","scheme":"http:\\/\\/scheme","compression":"gzip","algorithm":"http:\\/\\/algorithm","originalLength":12030}
+            {"algorithm":"http:\\/\\/algorithm","compression":"gzip","originalLength":12030,"profile":"http:\\/\\/profile","scheme":"http:\\/\\/scheme"}
             """)
     }
     

--- a/r2-shared-swiftTests/Publication/Link/EncryptionTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/EncryptionTests.swift
@@ -1,0 +1,41 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class EncryptionTests: XCTestCase {
+    
+    func toJSON(_ publication: Encryption) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+    
+    func testEmptyJSONSerialization() {
+        let sut = Encryption()
+        
+        XCTAssertEqual(toJSON(sut), """
+            {}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        var sut = Encryption()
+        sut.algorithm = "http://algorithm"
+        sut.compression = "gzip"
+        sut.originalLength = 12030
+        sut.profile = "http://profile"
+        sut.scheme = "http://scheme"
+
+        XCTAssertEqual(toJSON(sut), """
+            {"profile":"http:\\/\\/profile","scheme":"http:\\/\\/scheme","compression":"gzip","algorithm":"http:\\/\\/algorithm","originalLength":12030}
+            """)
+    }
+    
+}

--- a/r2-shared-swiftTests/Publication/Link/LinkTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/LinkTests.swift
@@ -1,0 +1,47 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class LinkTests: XCTestCase {
+    
+    func toJSON(_ publication: Link) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+    
+    func testEmptyJSONSerialization() {
+        let sut = Link()
+        
+        XCTAssertEqual(toJSON(sut), """
+            {}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        let sut = Link()
+        sut.href = "http://my.link"
+        sut.absoluteHref = "http://absolute.com"
+        sut.typeLink = "text/html"
+        sut.rel = ["rel1", "rel2"]
+        sut.height = 100
+        sut.width = 200
+        sut.title = "Title"
+        sut.properties.orientation = "landscape"
+        sut.duration = 120
+        sut.templated = true
+        sut.bitrate = 50
+        
+        XCTAssertEqual(toJSON(sut), """
+            {"height":100,"href":"http:\\/\\/my.link","width":200,"title":"Title","type":"text\\/html","rel":["rel1","rel2"],"duration":120,"properties":{"orientation":"landscape"}}
+            """)
+    }
+
+}

--- a/r2-shared-swiftTests/Publication/Link/LinkTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/LinkTests.swift
@@ -7,15 +7,10 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class LinkTests: XCTestCase {
-    
-    func toJSON(_ publication: Link) -> String? {
-        return Mapper().toJSONString(publication)
-    }
     
     func testEmptyJSONSerialization() {
         let sut = Link()
@@ -40,7 +35,7 @@ class LinkTests: XCTestCase {
         sut.bitrate = 50
         
         XCTAssertEqual(toJSON(sut), """
-            {"height":100,"href":"http:\\/\\/my.link","width":200,"title":"Title","type":"text\\/html","rel":["rel1","rel2"],"duration":120,"properties":{"orientation":"landscape"}}
+            {"duration":120,"height":100,"href":"http:\\/\\/my.link","properties":{"orientation":"landscape"},"rel":["rel1","rel2"],"title":"Title","type":"text\\/html","width":200}
             """)
     }
 

--- a/r2-shared-swiftTests/Publication/Link/PropertiesTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/PropertiesTests.swift
@@ -1,0 +1,52 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class PropertiesTests: XCTestCase {
+    
+    func toJSON(_ publication: Properties) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+    
+    func testEmptyJSONSerialization() {
+        let sut = Properties()
+        
+        XCTAssertEqual(toJSON(sut), """
+            {}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        func encryption() -> Encryption {
+            var encryption = Encryption()
+            encryption.algorithm = "http://algorithm"
+            return encryption
+        }
+
+        var sut = Properties()
+        sut.orientation = "portrait"
+        sut.page = "center"
+        sut.contains = ["stuff", "thing"]
+        sut.mediaOverlay = "http://media-overlay-location.com"
+        sut.encryption = encryption()
+        sut.layout = "reflowable"
+        sut.overflow = "paginated"
+        sut.spread = "auto"
+        sut.numberOfItems = 3
+        sut.price = Price(currency: "EUR", value: 3.29)
+
+        XCTAssertEqual(toJSON(sut), """
+            {"encryption":{"algorithm":"http:\\/\\/algorithm"},"page":"center","contains":["stuff","thing"],"spread":"auto","layout":"reflowable","mediaOverlay":"http:\\/\\/media-overlay-location.com","overflow":"paginated","orientation":"portrait"}
+            """)
+    }
+    
+}

--- a/r2-shared-swiftTests/Publication/Link/PropertiesTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/PropertiesTests.swift
@@ -7,15 +7,10 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class PropertiesTests: XCTestCase {
-    
-    func toJSON(_ publication: Properties) -> String? {
-        return Mapper().toJSONString(publication)
-    }
     
     func testEmptyJSONSerialization() {
         let sut = Properties()
@@ -45,7 +40,7 @@ class PropertiesTests: XCTestCase {
         sut.price = Price(currency: "EUR", value: 3.29)
 
         XCTAssertEqual(toJSON(sut), """
-            {"encryption":{"algorithm":"http:\\/\\/algorithm"},"page":"center","contains":["stuff","thing"],"spread":"auto","layout":"reflowable","mediaOverlay":"http:\\/\\/media-overlay-location.com","overflow":"paginated","orientation":"portrait"}
+            {"contains":["stuff","thing"],"encryption":{"algorithm":"http:\\/\\/algorithm"},"layout":"reflowable","mediaOverlay":"http:\\/\\/media-overlay-location.com","orientation":"portrait","overflow":"paginated","page":"center","spread":"auto"}
             """)
     }
     

--- a/r2-shared-swiftTests/Publication/Link/RenditionTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/RenditionTests.swift
@@ -7,15 +7,10 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class RenditionTests: XCTestCase {
-    
-    func toJSON(_ publication: Rendition) -> String? {
-        return Mapper().toJSONString(publication)
-    }
     
     func testEmptyJSONSerialization() {
         let sut = Rendition()
@@ -34,7 +29,7 @@ class RenditionTests: XCTestCase {
         sut.viewport = "1280x720"
 
         XCTAssertEqual(toJSON(sut), """
-            {"viewport":"1280x720","layout":"reflowable","flow":"paginated","spread":"auto","orientation":"landscape"}
+            {"flow":"paginated","layout":"reflowable","orientation":"landscape","spread":"auto","viewport":"1280x720"}
             """)
     }
     

--- a/r2-shared-swiftTests/Publication/Link/RenditionTests.swift
+++ b/r2-shared-swiftTests/Publication/Link/RenditionTests.swift
@@ -1,0 +1,41 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class RenditionTests: XCTestCase {
+    
+    func toJSON(_ publication: Rendition) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+    
+    func testEmptyJSONSerialization() {
+        let sut = Rendition()
+        
+        XCTAssertEqual(toJSON(sut), """
+            {}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        let sut = Rendition()
+        sut.layout = .reflowable
+        sut.flow = .paginated
+        sut.orientation = .landscape
+        sut.spread = .auto
+        sut.viewport = "1280x720"
+
+        XCTAssertEqual(toJSON(sut), """
+            {"viewport":"1280x720","layout":"reflowable","flow":"paginated","spread":"auto","orientation":"landscape"}
+            """)
+    }
+    
+}

--- a/r2-shared-swiftTests/Publication/Metadata/ContributorTests.swift
+++ b/r2-shared-swiftTests/Publication/Metadata/ContributorTests.swift
@@ -7,15 +7,10 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class ContributorTests: XCTestCase {
-    
-    func toJSON(_ publication: Contributor) -> String? {
-        return Mapper().toJSONString(publication)
-    }
     
     func multilangString(_ title: String?, _ strings: [String: String] = [:]) -> MultilangString {
         let string = MultilangString()
@@ -45,9 +40,9 @@ class ContributorTests: XCTestCase {
         sut.identifier = "identifier"
         sut.roles = ["role1", "role2"]
         sut.links = [link("link1"), link("link2")]
-
+        
         XCTAssertEqual(toJSON(sut), """
-            {"name":"Name","sortAs":"sorting","roles":["role1","role2"],"identifier":"identifier"}
+            {"identifier":"identifier","name":"Name","roles":["role1","role2"],"sortAs":"sorting"}
             """)
     }
     
@@ -56,7 +51,7 @@ class ContributorTests: XCTestCase {
         sut.multilangName = multilangString("Michael", ["fr": "Mickaël", "en": "Michael"])
 
         XCTAssertEqual(toJSON(sut), """
-            {"name":{"fr":"Mickaël","en":"Michael"}}
+            {"name":{"en":"Michael","fr":"Mickaël"}}
             """)
     }
     

--- a/r2-shared-swiftTests/Publication/Metadata/ContributorTests.swift
+++ b/r2-shared-swiftTests/Publication/Metadata/ContributorTests.swift
@@ -1,0 +1,63 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class ContributorTests: XCTestCase {
+    
+    func toJSON(_ publication: Contributor) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+    
+    func multilangString(_ title: String?, _ strings: [String: String] = [:]) -> MultilangString {
+        let string = MultilangString()
+        string.singleString = title
+        string.multiString = strings
+        return string
+    }
+
+    func link(_ title: String) -> Link {
+        let link = Link()
+        link.title = title
+        return link
+    }
+    
+    func testEmptyJSONSerialization() {
+        let sut = Contributor()
+        
+        XCTAssertEqual(toJSON(sut), """
+            {"name":""}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        let sut = Contributor()
+        sut.multilangName = multilangString("Name")
+        sut.sortAs = "sorting"
+        sut.identifier = "identifier"
+        sut.roles = ["role1", "role2"]
+        sut.links = [link("link1"), link("link2")]
+
+        XCTAssertEqual(toJSON(sut), """
+            {"name":"Name","sortAs":"sorting","roles":["role1","role2"],"identifier":"identifier"}
+            """)
+    }
+    
+    func testJSONSerializationWithLocalizedName() {
+        let sut = Contributor()
+        sut.multilangName = multilangString("Michael", ["fr": "Mickaël", "en": "Michael"])
+
+        XCTAssertEqual(toJSON(sut), """
+            {"name":{"fr":"Mickaël","en":"Michael"}}
+            """)
+    }
+    
+}

--- a/r2-shared-swiftTests/Publication/Metadata/MultilangStringTests.swift
+++ b/r2-shared-swiftTests/Publication/Metadata/MultilangStringTests.swift
@@ -1,0 +1,47 @@
+//
+//  Created by Mickaël Menu on 28.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import XCTest
+@testable import R2Shared
+
+class MultilangStringTests: XCTestCase {
+    
+    // JSONEncoder doesn't allow fragments, so we wrap the SUT in an array before encoding to JSON, because MultilangString is not a full-fledge JSON object.
+
+    func testEmptyJSONSerialization() {
+        let sut = MultilangString()
+        
+        XCTAssertEqual(toJSON([sut]), """
+            [""]
+            """)
+    }
+    
+    func testNonLocalizedJSONSerialization() {
+        let sut = MultilangString()
+        sut.singleString = "apple"
+        
+        XCTAssertEqual(toJSON([sut]), """
+            ["apple"]
+            """)
+    }
+    
+    func testLocalizedJSONSerialization() {
+        let sut = MultilangString()
+        sut.singleString = "apple"
+        sut.multiString = [
+            "fr": "pomme",
+            "de": "Apfel"
+        ]
+        
+        XCTAssertEqual(toJSON([sut]), """
+            [{"de":"Apfel","fr":"pomme"}]
+            """)
+    }
+
+}

--- a/r2-shared-swiftTests/Publication/Metadata/SubjectTests.swift
+++ b/r2-shared-swiftTests/Publication/Metadata/SubjectTests.swift
@@ -1,0 +1,48 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class SubjectTests: XCTestCase {
+    
+    func toJSON(_ publication: Subject) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+
+    func testEmptyJSONSerialization() {
+        let sut = Subject()
+
+        XCTAssertEqual(toJSON(sut), """
+            {}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        func link(_ title: String) -> Link {
+            let link = Link()
+            link.title = title
+            return link
+        }
+        
+        
+        let sut = Subject()
+        sut.name = "Name"
+        sut.sortAs = "sorting"
+        sut.scheme = "a-scheme"
+        sut.code = "a-code"
+        sut.links = [link("link1"), link("link2")]
+
+        XCTAssertEqual(toJSON(sut), """
+            {"name":"Name","scheme":"a-scheme","sortAs":"sorting","code":"a-code"}
+            """)
+    }
+
+}

--- a/r2-shared-swiftTests/Publication/Metadata/SubjectTests.swift
+++ b/r2-shared-swiftTests/Publication/Metadata/SubjectTests.swift
@@ -7,19 +7,14 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class SubjectTests: XCTestCase {
-    
-    func toJSON(_ publication: Subject) -> String? {
-        return Mapper().toJSONString(publication)
-    }
 
     func testEmptyJSONSerialization() {
         let sut = Subject()
-
+        
         XCTAssertEqual(toJSON(sut), """
             {}
             """)
@@ -39,9 +34,9 @@ class SubjectTests: XCTestCase {
         sut.scheme = "a-scheme"
         sut.code = "a-code"
         sut.links = [link("link1"), link("link2")]
-
+        
         XCTAssertEqual(toJSON(sut), """
-            {"name":"Name","scheme":"a-scheme","sortAs":"sorting","code":"a-code"}
+            {"code":"a-code","name":"Name","scheme":"a-scheme","sortAs":"sorting"}
             """)
     }
 

--- a/r2-shared-swiftTests/Publication/MetadataTests.swift
+++ b/r2-shared-swiftTests/Publication/MetadataTests.swift
@@ -7,21 +7,16 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class MetadataTests: XCTestCase {
-
-    func toJSON(_ publication: Metadata) -> String? {
-        return Mapper().toJSONString(publication)
-    }
     
     func testEmptyJSONSerialization() {
         let sut = Metadata()
-        
+       
         XCTAssertEqual(toJSON(sut), """
-            {"languages":[],"title":"","subtitle":""}
+            {"languages":[],"title":""}
             """)
     }
     
@@ -106,7 +101,7 @@ class MetadataTests: XCTestCase {
         sut.duration = 56
         
         XCTAssertEqual(toJSON(sut), """
-            {"rendition":{"viewport":"1280x760","layout":"reflowable","flow":"paginated","spread":"landscape","orientation":"auto"},"source":"Source","pencilers":[{"name":"Penciler"}],"authors":[{"name":"Author"}],"editors":[{"name":"Editor"}],"languages":["fr","en"],"narrators":[{"name":"Narrator"}],"inkers":[{"name":"Inker"}],"letterers":[{"name":"Letterer"}],"artists":[{"name":"Artist"}],"colorists":[{"name":"Colorist"}],"identifier":"1234","modified":"2001-01-01T00:39:10+0000","published":"2016-09-02","subtitle":"Title","illustrators":[{"name":"Illustrator"}],"contributors":[{"name":"Contributor"}],"imprints":[{"name":"Imprint"}],"title":"Title","rights":"rights","translators":[{"name":"Translator"}],"publishers":[{"name":"Publisher 1"},{"name":"Publisher 2"}],"subjects":[{"name":"tourism"},{"name":"exploration"}]}
+            {"artists":[{"name":"Artist"}],"authors":[{"name":"Author"}],"colorists":[{"name":"Colorist"}],"contributors":[{"name":"Contributor"}],"editors":[{"name":"Editor"}],"identifier":"1234","illustrators":[{"name":"Illustrator"}],"imprints":[{"name":"Imprint"}],"inkers":[{"name":"Inker"}],"languages":["fr","en"],"letterers":[{"name":"Letterer"}],"modified":"2001-01-01T00:39:10+0000","narrators":[{"name":"Narrator"}],"pencilers":[{"name":"Penciler"}],"published":"2016-09-02","publishers":[{"name":"Publisher 1"},{"name":"Publisher 2"}],"rendition":{"flow":"paginated","layout":"reflowable","orientation":"auto","spread":"landscape","viewport":"1280x760"},"rights":"rights","source":"Source","subjects":[{"name":"tourism"},{"name":"exploration"}],"subtitle":"Subtitle","title":"Title","translators":[{"name":"Translator"}]}
             """)
     }
     
@@ -124,7 +119,7 @@ class MetadataTests: XCTestCase {
         sut.multilangSubtitle = multilangString(nil, ["fr": "Sous-titre"])
 
         XCTAssertEqual(toJSON(sut), """
-            {"languages":[],"title":{"fr":"Titre","de":"Titel"},"subtitle":{"fr":"Titre","de":"Titel"}}
+            {"languages":[],"subtitle":{"fr":"Sous-titre"},"title":{"de":"Titel","fr":"Titre"}}
             """)
     }
 

--- a/r2-shared-swiftTests/Publication/MetadataTests.swift
+++ b/r2-shared-swiftTests/Publication/MetadataTests.swift
@@ -1,0 +1,131 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class MetadataTests: XCTestCase {
+
+    func toJSON(_ publication: Metadata) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+    
+    func testEmptyJSONSerialization() {
+        let sut = Metadata()
+        
+        XCTAssertEqual(toJSON(sut), """
+            {"languages":[],"title":"","subtitle":""}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        func multilangString(_ title: String) -> MultilangString {
+            let string = MultilangString()
+            string.singleString = title
+            return string
+        }
+        
+        func contributor(_ name: String) -> Contributor {
+            let contributor = Contributor()
+            contributor.multilangName = multilangString(name)
+            return contributor
+        }
+        
+        func subject(_ name: String) -> Subject {
+            let subject = Subject()
+            subject.name = name
+            return subject
+        }
+        
+        func rendition() -> Rendition {
+            let rendition = Rendition()
+            rendition.layout = .reflowable
+            rendition.flow = .paginated
+            rendition.orientation = .auto
+            rendition.spread = .landscape
+            rendition.viewport = "1280x760"
+            return rendition
+        }
+        
+        func metadata(_ property: String, _ value: String) -> MetadataItem {
+            let item = MetadataItem()
+            item.property = property
+            item.value = value
+            return item
+        }
+        
+        func collection(_ name: String) -> R2Shared.Collection {
+            return Collection(name: name)
+        }
+        
+        func belongsTo() -> BelongsTo {
+            let belongsTo = BelongsTo()
+            belongsTo.series = [collection("Serie 1")]
+            belongsTo.collection = [collection("Collection 1"), collection("Collection 2")]
+            return belongsTo
+        }
+        
+        
+        let sut = Metadata()
+        sut.multilangTitle = multilangString("Title")
+        sut.multilangSubtitle = multilangString("Subtitle")
+        sut.direction = .ltr
+        sut.languages = ["fr", "en"]
+        sut.identifier = "1234"
+        sut.publishers = [contributor("Publisher 1"), contributor("Publisher 2")]
+        sut.imprints = [contributor("Imprint")]
+        sut.contributors = [contributor("Contributor")]
+        sut.authors = [contributor("Author")]
+        sut.translators = [contributor("Translator")]
+        sut.editors = [contributor("Editor")]
+        sut.artists = [contributor("Artist")]
+        sut.illustrators = [contributor("Illustrator")]
+        sut.letterers = [contributor("Letterer")]
+        sut.pencilers = [contributor("Penciler")]
+        sut.colorists = [contributor("Colorist")]
+        sut.inkers = [contributor("Inker")]
+        sut.narrators = [contributor("Narrator")]
+        sut.subjects = [subject("tourism"), subject("exploration")]
+        sut.modified = Date(timeIntervalSinceReferenceDate: 2350)
+        sut.published = "2016-09-02"
+        sut.description = "Description"
+        sut.rendition = rendition()
+        sut.source = "Source"
+        sut.epubType = ["type1", "type2"]
+        sut.rights = "rights"
+        sut.rdfType = "rdftype"
+        sut.otherMetadata = [metadata("key1", "value1"), metadata("key2", "value2")]
+        sut.belongsTo = belongsTo()
+        sut.duration = 56
+        
+        XCTAssertEqual(toJSON(sut), """
+            {"rendition":{"viewport":"1280x760","layout":"reflowable","flow":"paginated","spread":"landscape","orientation":"auto"},"source":"Source","pencilers":[{"name":"Penciler"}],"authors":[{"name":"Author"}],"editors":[{"name":"Editor"}],"languages":["fr","en"],"narrators":[{"name":"Narrator"}],"inkers":[{"name":"Inker"}],"letterers":[{"name":"Letterer"}],"artists":[{"name":"Artist"}],"colorists":[{"name":"Colorist"}],"identifier":"1234","modified":"2001-01-01T00:39:10+0000","published":"2016-09-02","subtitle":"Title","illustrators":[{"name":"Illustrator"}],"contributors":[{"name":"Contributor"}],"imprints":[{"name":"Imprint"}],"title":"Title","rights":"rights","translators":[{"name":"Translator"}],"publishers":[{"name":"Publisher 1"},{"name":"Publisher 2"}],"subjects":[{"name":"tourism"},{"name":"exploration"}]}
+            """)
+    }
+    
+    func testJSONSerializationWithLocalizedTitles() {
+        func multilangString(_ title: String?, _ strings: [String: String] = [:]) -> MultilangString {
+            let string = MultilangString()
+            string.singleString = title
+            string.multiString = strings
+            return string
+        }
+        
+        
+        let sut = Metadata()
+        sut.multilangTitle = multilangString("Title", ["fr": "Titre", "de": "Titel"])
+        sut.multilangSubtitle = multilangString(nil, ["fr": "Sous-titre"])
+
+        XCTAssertEqual(toJSON(sut), """
+            {"languages":[],"title":{"fr":"Titre","de":"Titel"},"subtitle":{"fr":"Titre","de":"Titel"}}
+            """)
+    }
+
+}

--- a/r2-shared-swiftTests/Publication/PublicationTests.swift
+++ b/r2-shared-swiftTests/Publication/PublicationTests.swift
@@ -7,67 +7,154 @@
 //  in the LICENSE file present in the project repository where this source code is maintained.
 //
 
-import ObjectMapper
 import XCTest
 @testable import R2Shared
 
 class PublicationTests: XCTestCase {
-    
-    func toJSON(_ publication: Publication) -> String? {
-        return Mapper().toJSONString(publication)
-    }
 
     func testEmptyJSONSerialization() {
         let sut = Publication()
         
         XCTAssertEqual(toJSON(sut), """
-            {"metadata":{"languages":[],"title":"","subtitle":""}}
+            {"metadata":{"languages":[],"title":""}}
             """)
     }
     
     func testJSONSerialization() {
-        func multilangString(_ title: String) -> MultilangString {
-            let string = MultilangString()
-            string.singleString = title
-            return string
-        }
-
-        func link(_ title: String) -> Link {
-            let link = Link()
-            link.title = title
-            return link
-        }
-        
-        func userProperties(_ props: [UserProperty]) -> UserProperties {
-            let userProperties = UserProperties()
-            userProperties.properties = props
-            return userProperties
-        }
-
-        let sut = Publication()
-        sut.version = 1.2
-        sut.metadata = Metadata()
-        sut.metadata.multilangTitle = multilangString("Title")
-        sut.links = [link("link1"), link("link2")]
-        sut.spine = [link("spine")]
-        sut.resources = [link("resource")]
-        sut.tableOfContents = [link("toc")]
-        sut.landmarks = [link("landmark")]
-        sut.listOfAudioFiles = [link("audio")]
-        sut.listOfIllustrations = [link("illustration")]
-        sut.listOfTables = [link("table")]
-        sut.listOfVideos = [link("video")]
-        sut.pageList = [link("page")]
-        sut.images = [link("image")]
-        sut.userProperties = userProperties([UserProperty("ref", "name")])
-        sut.updatedDate = Date(timeIntervalSinceReferenceDate: 8374)
-        sut.otherLinks = [link("otherlink")]
-        sut.internalData = ["data1": "value1"]
-        sut.userSettingsUIPreset = [.fontSize: true]
+        let sut = publication()
 
         XCTAssertEqual(toJSON(sut), """
-            {"metadata":{"languages":[],"title":"Title","subtitle":"Title"},"page-list":[{"title":"page"}],"loi":[{"title":"illustration"}],"lot":[{"title":"table"}],"landmarks":[{"title":"landmark"}],"spine":[{"title":"spine"}],"links":[{"title":"link1"},{"title":"link2"}],"resources":[{"title":"resource"}],"toc":[{"title":"toc"}]}
+            {"landmarks":[{"title":"landmark"}],"links":[{"title":"link1"},{"title":"link2"}],"loi":[{"title":"illustration"}],"lot":[{"title":"table"}],"metadata":{"languages":[],"title":"Title"},"page-list":[{"title":"page"}],"resources":[{"title":"resource"}],"spine":[{"title":"spine"}],"toc":[{"title":"toc"}]}
             """)
     }
+    
+    func testManifest() {
+        let sut = publication()
+        // To check that slashes are not escaped
+        sut.links.append(link("link-url", href: "http://link.com"))
+        
+        XCTAssertEqual(sut.manifest, """
+            {
+              "loi" : [
+                {
+                  "title" : "illustration"
+                }
+              ],
+              "resources" : [
+                {
+                  "title" : "resource"
+                }
+              ],
+              "landmarks" : [
+                {
+                  "title" : "landmark"
+                }
+              ],
+              "spine" : [
+                {
+                  "title" : "spine"
+                }
+              ],
+              "links" : [
+                {
+                  "title" : "link1"
+                },
+                {
+                  "title" : "link2"
+                },
+                {
+                  "title" : "link-url",
+                  "href" : "http://link.com"
+                }
+              ],
+              "lot" : [
+                {
+                  "title" : "table"
+                }
+              ],
+              "page-list" : [
+                {
+                  "title" : "page"
+                }
+              ],
+              "metadata" : {
+                "title" : "Title",
+                "languages" : [
 
+                ]
+              },
+              "toc" : [
+                {
+                  "title" : "toc"
+                }
+              ]
+            }
+            """)
+    }
+    
+    
+    func testManifestCanonical() {
+        let sut = publication()
+        // To check that slashes are not escaped
+        sut.landmarks.append(link("landmark", href: "http://link.com"))
+        // To check that links are removed
+        sut.links.append(link("link", href: "http://link.com"))
+        
+        XCTAssertEqual(sut.manifestCanonical, """
+            {"landmarks":[{"title":"landmark"},{"href":"http://link.com","title":"landmark"}],"loi":[{"title":"illustration"}],"lot":[{"title":"table"}],"metadata":{"languages":[],"title":"Title"},"page-list":[{"title":"page"}],"resources":[{"title":"resource"}],"spine":[{"title":"spine"}],"toc":[{"title":"toc"}]}
+            """)
+    }
+    
+    func testManifestDictionary() {
+        let sut = publication()
+        
+        let json = String(data: try! JSONSerialization.data(withJSONObject: sut.manifestDictionnary, options: [.sortedKeys]), encoding: .utf8)!
+        XCTAssertEqual(json, """
+            {"landmarks":[{"title":"landmark"}],"links":[{"title":"link1"},{"title":"link2"}],"loi":[{"title":"illustration"}],"lot":[{"title":"table"}],"metadata":{"languages":[],"title":"Title"},"page-list":[{"title":"page"}],"resources":[{"title":"resource"}],"spine":[{"title":"spine"}],"toc":[{"title":"toc"}]}
+            """)
+    }
+    
+    func publication() -> Publication {
+        let publication = Publication()
+        publication.version = 1.2
+        publication.metadata = Metadata()
+        publication.metadata.multilangTitle = multilangString("Title")
+        publication.links = [link("link1"), link("link2")]
+        publication.spine = [link("spine")]
+        publication.resources = [link("resource")]
+        publication.tableOfContents = [link("toc")]
+        publication.landmarks = [link("landmark")]
+        publication.listOfAudioFiles = [link("audio")]
+        publication.listOfIllustrations = [link("illustration")]
+        publication.listOfTables = [link("table")]
+        publication.listOfVideos = [link("video")]
+        publication.pageList = [link("page")]
+        publication.images = [link("image")]
+        publication.userProperties = userProperties([UserProperty("ref", "name")])
+        publication.updatedDate = Date(timeIntervalSinceReferenceDate: 8374)
+        publication.otherLinks = [link("otherlink")]
+        publication.internalData = ["data1": "value1"]
+        publication.userSettingsUIPreset = [.fontSize: true]
+        return publication
+    }
+    
+    func multilangString(_ title: String) -> MultilangString {
+        let string = MultilangString()
+        string.singleString = title
+        return string
+    }
+    
+    func link(_ title: String, href: String? = nil) -> Link {
+        let link = Link()
+        link.title = title
+        link.href = href
+        return link
+    }
+    
+    func userProperties(_ props: [UserProperty]) -> UserProperties {
+        let userProperties = UserProperties()
+        userProperties.properties = props
+        return userProperties
+    }
+    
 }

--- a/r2-shared-swiftTests/Publication/PublicationTests.swift
+++ b/r2-shared-swiftTests/Publication/PublicationTests.swift
@@ -1,0 +1,73 @@
+//
+//  Created by Mickaël Menu on 25.01.19.
+//  Copyright © 2019 Readium. All rights reserved.
+//
+//  Copyright 2019 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import ObjectMapper
+import XCTest
+@testable import R2Shared
+
+class PublicationTests: XCTestCase {
+    
+    func toJSON(_ publication: Publication) -> String? {
+        return Mapper().toJSONString(publication)
+    }
+
+    func testEmptyJSONSerialization() {
+        let sut = Publication()
+        
+        XCTAssertEqual(toJSON(sut), """
+            {"metadata":{"languages":[],"title":"","subtitle":""}}
+            """)
+    }
+    
+    func testJSONSerialization() {
+        func multilangString(_ title: String) -> MultilangString {
+            let string = MultilangString()
+            string.singleString = title
+            return string
+        }
+
+        func link(_ title: String) -> Link {
+            let link = Link()
+            link.title = title
+            return link
+        }
+        
+        func userProperties(_ props: [UserProperty]) -> UserProperties {
+            let userProperties = UserProperties()
+            userProperties.properties = props
+            return userProperties
+        }
+
+        let sut = Publication()
+        sut.version = 1.2
+        sut.metadata = Metadata()
+        sut.metadata.multilangTitle = multilangString("Title")
+        sut.links = [link("link1"), link("link2")]
+        sut.spine = [link("spine")]
+        sut.resources = [link("resource")]
+        sut.tableOfContents = [link("toc")]
+        sut.landmarks = [link("landmark")]
+        sut.listOfAudioFiles = [link("audio")]
+        sut.listOfIllustrations = [link("illustration")]
+        sut.listOfTables = [link("table")]
+        sut.listOfVideos = [link("video")]
+        sut.pageList = [link("page")]
+        sut.images = [link("image")]
+        sut.userProperties = userProperties([UserProperty("ref", "name")])
+        sut.updatedDate = Date(timeIntervalSinceReferenceDate: 8374)
+        sut.otherLinks = [link("otherlink")]
+        sut.internalData = ["data1": "value1"]
+        sut.userSettingsUIPreset = [.fontSize: true]
+
+        XCTAssertEqual(toJSON(sut), """
+            {"metadata":{"languages":[],"title":"Title","subtitle":"Title"},"page-list":[{"title":"page"}],"loi":[{"title":"illustration"}],"lot":[{"title":"table"}],"landmarks":[{"title":"landmark"}],"spine":[{"title":"spine"}],"links":[{"title":"link1"},{"title":"link2"}],"resources":[{"title":"resource"}],"toc":[{"title":"toc"}]}
+            """)
+    }
+
+}


### PR DESCRIPTION
Closes #3 

ObjectMapper was replaced by Swift 4's Encodable.

Unit tests validated that the JSON serialization is compatible with the one generated by ObjectMapper.