### PR TITLE
Update `pageListKey` to value `pageList`

### DIFF
--- a/r2-shared-swift/Publication/EPUB/Publication+EPUB.swift
+++ b/r2-shared-swift/Publication/EPUB/Publication+EPUB.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-private let pageListKey = "page-list"
+private let pageListKey = "pageList"
 private let landmarksKey = "landmarks"
 private let loaKey = "loa"
 private let loiKey = "loi"

--- a/r2-shared-swiftTests/Publication/EPUB/Publication+EPUBTests.swift
+++ b/r2-shared-swiftTests/Publication/EPUB/Publication+EPUBTests.swift
@@ -26,7 +26,7 @@ class PublicationEPUBTests: XCTestCase {
 
     func testPageList() {
         sut.otherCollections.append(
-            PublicationCollection(role: "page-list", links: [Link(href: "/page1.html")])
+            PublicationCollection(role: "pageList", links: [Link(href: "/page1.html")])
         )
         
         XCTAssertEqual(


### PR DESCRIPTION
The webpub-manifest is changing to have the page list role be in camel case:
https://github.com/readium/webpub-manifest/issues/53