### PR TITLE
Fix regression when reading ZIP entries

### DIFF
--- a/r2-shared-swift/Toolkit/Archive/Minizip.swift
+++ b/r2-shared-swift/Toolkit/Archive/Minizip.swift
@@ -175,7 +175,8 @@ private extension MinizipArchive {
             return false
         }
         
-        if entry.isCompressed {
+        // FIXME: https://github.com/readium/r2-shared-swift/issues/98
+        if true || entry.isCompressed {
             // Deflate is stream-based, and can't be used for random access. Therefore, if the file
             // is compressed we need to read and discard the content from the start until we reach
             // the desired offset.

--- a/r2-shared-swiftTests/Toolkit/Archive/ArchiveTests.swift
+++ b/r2-shared-swiftTests/Toolkit/Archive/ArchiveTests.swift
@@ -118,7 +118,6 @@ struct ZIPTester<A: Archive> {
     }
     
     func testReadUncompressedRange() {
-        // FIXME: It looks like unzseek64 starts from the beginning of the file header, instead of the content. Reading a first byte solves this but then Minizip crashes randomly... Note that this only fails in the test case. I didn't see actual issues in LCPDF or videos embedded in EPUBs.
         let archive = try! A(file: fixtures.url(for: "test.zip"))
         let entry = archive.entry(at: "A folder/Sub.folder%/file.txt")!
         let data = archive.read(at: entry.path, range: 14..<20)


### PR DESCRIPTION
See https://github.com/readium/r2-shared-swift/issues/98