### PR TITLE
Make Locator hashable

### DIFF
--- a/r2-shared-swift/Publication/Locator.swift
+++ b/r2-shared-swift/Publication/Locator.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// https://github.com/readium/architecture/tree/master/locators
-public struct Locator: Equatable, CustomStringConvertible, Loggable {
+public struct Locator: Hashable, CustomStringConvertible, Loggable {
 
     /// The URI of the resource that the Locator Object points to.
     public let href: String  // URI
@@ -114,7 +114,7 @@ public struct Locator: Equatable, CustomStringConvertible, Loggable {
     ///
     /// Properties are mutable for convenience when making a copy, but the `locations` property
     /// is immutable in `Locator`, for safety.
-    public struct Locations: Equatable, Loggable {
+    public struct Locations: Hashable, Loggable {
         /// Contains one or more fragment in the resource referenced by the `Locator`.
         public var fragments: [String]
         /// Progression in the resource expressed as a percentage (between 0 and 1).
@@ -201,7 +201,7 @@ public struct Locator: Equatable, CustomStringConvertible, Loggable {
         
     }
     
-    public struct Text: Equatable, Loggable {
+    public struct Text: Hashable, Loggable {
         public var after: String?
         public var before: String?
         public var highlight: String?

--- a/r2-shared-swift/Publication/Publication+JSON.swift
+++ b/r2-shared-swift/Publication/Publication+JSON.swift
@@ -74,7 +74,8 @@ extension JSONDictionary: Equatable {
     
     static func == (lhs: JSONDictionary, rhs: JSONDictionary) -> Bool {
         guard #available(iOS 11.0, *) else {
-            // The JSON comparison is not reliable before iOS 11, because the keys order is not deterministic. Since the equality is only tested during unit tests, it's not such a problem.
+            // The JSON comparison is not reliable before iOS 11, because the keys order is not
+            // deterministic.
             return false
         }
         
@@ -85,6 +86,22 @@ extension JSONDictionary: Equatable {
 
 }
 
+extension JSONDictionary: Hashable {
+    
+    func hash(into hasher: inout Hasher) {
+        guard #available(iOS 11.0, *) else {
+            // The JSON comparison is not reliable before iOS 11, because the keys order is not
+            // deterministic.
+            hasher.combine(UUID().uuidString)
+            return
+        }
+        
+        let jsonString = (try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]))
+            .map { String(data: $0, encoding: .utf8) }
+        hasher.combine(jsonString ?? "{}")
+    }
+    
+}
 
 // MARK: - JSON Parsing
 


### PR DESCRIPTION
This is useful to have a `Locator` property in a model used with a diffable data source, for example with the outline.