### PR TITLE
Improve LinkRelation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* Add a new `LinkRelation` type to represent link relations, instead of using raw strings.
+  * This will improve code safety through type checking and enable code completion.
+  * Since `LinkRelation` conforms to `ExpressibleByStringLiteral`, you can continue using raw strings in the API. However, migrating your code is recommended, e.g. `links.first(withRel: .cover)`.
+  * Known link relations (including from OPDS specifications) are available under the `LinkRelation` namespace. You can easily add custom relations to the namespace by declaring `static` properties in a `LinkRelation` extension.
+
 ## [2.0.0-alpha.1]
 
 ### Added

--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		CA3386F024056E7A00FDCBBA /* Locator+HTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3386EF24056E7A00FDCBBA /* Locator+HTMLTests.swift */; };
 		CA40C07A21FF25F80069A50E /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA40C07921FF25F80069A50E /* JSON.swift */; };
 		CA50B86E22B2A1CF003AFF24 /* R2LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA50B86D22B2A1CF003AFF24 /* R2LocalizedString.swift */; };
+		CA54A8DD252339AF00CEE5A6 /* LinkRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA54A8DC252339AF00CEE5A6 /* LinkRelation.swift */; };
 		CA5B7C372441B492003A2FE7 /* Fixtures in Resources */ = {isa = PBXBuildFile; fileRef = CA5B7C362441B492003A2FE7 /* Fixtures */; };
 		CA5B7C392441BA5F003A2FE7 /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B7C382441BA5F003A2FE7 /* Fixtures.swift */; };
 		CA5F8EE92404035D00926120 /* ReadingProgression.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5F8EE82404035C00926120 /* ReadingProgression.swift */; };
@@ -249,6 +250,7 @@
 		CA3386EF24056E7A00FDCBBA /* Locator+HTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locator+HTMLTests.swift"; sourceTree = "<group>"; };
 		CA40C07921FF25F80069A50E /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		CA50B86D22B2A1CF003AFF24 /* R2LocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = R2LocalizedString.swift; sourceTree = "<group>"; };
+		CA54A8DC252339AF00CEE5A6 /* LinkRelation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkRelation.swift; sourceTree = "<group>"; };
 		CA5B7C362441B492003A2FE7 /* Fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Fixtures; sourceTree = "<group>"; };
 		CA5B7C382441BA5F003A2FE7 /* Fixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixtures.swift; sourceTree = "<group>"; };
 		CA5F8EE82404035C00926120 /* ReadingProgression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingProgression.swift; sourceTree = "<group>"; };
@@ -432,6 +434,7 @@
 				CA228D1C24BD990000879E2E /* ContentProtection.swift */,
 				CA5F8EE82404035C00926120 /* ReadingProgression.swift */,
 				CA16A86F2232F7CD00E66255 /* Link.swift */,
+				CA54A8DC252339AF00CEE5A6 /* LinkRelation.swift */,
 				CA16A8712232FBBB00E66255 /* Properties.swift */,
 				CA9FC06E24824C3B0020B9CC /* Manifest.swift */,
 				CA16A8812233FE3200E66255 /* Metadata.swift */,
@@ -1144,6 +1147,7 @@
 				CA60CE242446E97400149B22 /* Fuzi.swift in Sources */,
 				CA8C84162468914900CE97A4 /* Resource.swift in Sources */,
 				CA62B37E24E02FA30046CDCF /* LazyResource.swift in Sources */,
+				CA54A8DD252339AF00CEE5A6 /* LinkRelation.swift in Sources */,
 				CA17637A223A7B8900959FEB /* Properties+OPDS.swift in Sources */,
 				CACD75E22236A0B7004F20CA /* Subject.swift in Sources */,
 				CACDE5D72483AAB0006FEB1B /* UIImage.swift in Sources */,

--- a/r2-shared-swift/Format/FormatSniffer.swift
+++ b/r2-shared-swift/Format/FormatSniffer.swift
@@ -460,7 +460,7 @@ private extension Manifest {
 
     /// Finds the first `Link` having the given `rel` matching the given `predicate`, in the
     /// publications' links.
-    func link(withRelMatching predicate: (Link.Relation) -> Bool) -> Link? {
+    func link(withRelMatching predicate: (LinkRelation) -> Bool) -> Link? {
         for link in links {
             for rel in link.rels {
                 if predicate(rel) {

--- a/r2-shared-swift/Format/MediaType.swift
+++ b/r2-shared-swift/Format/MediaType.swift
@@ -155,6 +155,16 @@ public struct MediaType: Equatable, Hashable {
         return other.contains { matches($0) }
     }
     
+    /// Returns whether this media type matches any of the `others` media types.
+    public func matchesAny(_ others: [Self]) -> Bool {
+        return others.contains { matches($0) }
+    }
+    
+    /// Returns whether this media type matches any of the `others` media types.
+    public func matchesAny(_ others: [String]) -> Bool {
+        return others.contains { matches($0) }
+    }
+
     /// Returns whether this media type is structured as a ZIP archive.
     public var isZIP: Bool {
         matchesAny(.zip, .lcpProtectedAudiobook, .lcpProtectedPDF) || structuredSyntaxSuffix == "+zip"

--- a/r2-shared-swift/OPDS/OPDSAcquisition.swift
+++ b/r2-shared-swift/OPDS/OPDSAcquisition.swift
@@ -19,6 +19,8 @@ public struct OPDSAcquisition: Equatable {
     public var type: String
     public var children: [OPDSAcquisition] = []
     
+    public var mediaType: MediaType? { MediaType(type) }
+    
     public init(type: String, children: [OPDSAcquisition] = []) {
         self.type = type
         self.children = children

--- a/r2-shared-swift/Publication/Link.swift
+++ b/r2-shared-swift/Publication/Link.swift
@@ -30,7 +30,7 @@ public struct Link: JSONEquatable {
     public let title: String?
     
     /// Relation between the linked resource and its containing collection.
-    public let rels: [Relation]
+    public let rels: [LinkRelation]
     
     /// Properties associated to the linked resource.
     public let properties: Properties
@@ -56,7 +56,7 @@ public struct Link: JSONEquatable {
     /// Resources that are children of the linked resource, in the context of a given collection role.
     public let children: [Link]
 
-    public init(href: String, type: String? = nil, templated: Bool = false, title: String? = nil, rels: [Relation] = [], rel: Relation? = nil, properties: Properties = Properties(), height: Int? = nil, width: Int? = nil, bitrate: Double? = nil, duration: Double? = nil, languages: [String] = [], alternates: [Link] = [], children: [Link] = []) {
+    public init(href: String, type: String? = nil, templated: Bool = false, title: String? = nil, rels: [LinkRelation] = [], rel: LinkRelation? = nil, properties: Properties = Properties(), height: Int? = nil, width: Int? = nil, bitrate: Double? = nil, duration: Double? = nil, languages: [String] = [], alternates: [Link] = [], children: [Link] = []) {
         // Convenience to set a single rel during construction.
         var rels = rels
         if let rel = rel {
@@ -164,7 +164,7 @@ public struct Link: JSONEquatable {
         type: String?? = nil,
         templated: Bool? = nil,
         title: String?? = nil,
-        rels: [Relation]? = nil,
+        rels: [LinkRelation]? = nil,
         properties: Properties? = nil,
         height: Int?? = nil,
         width: Int?? = nil,
@@ -195,90 +195,6 @@ public struct Link: JSONEquatable {
     public func addingProperties(_ properties: [String: Any]) -> Link {
         copy(properties: self.properties.adding(properties))
     }
-    
-    /// Link relations as defined on https://readium.org/webpub-manifest/relationships.html
-    public enum Relation: ExpressibleByStringLiteral, RawRepresentable, Hashable {
-        /// Designates a substitute for the link's context.
-        case alternate
-        /// Refers to a table of contents.
-        case contents
-        /// Refers to a publication's cover.
-        case cover
-        /// Links to a manifest.
-        case manifest
-        /// Refers to a URI or templated URI that will perform a search.
-        case search
-        /// Conveys an identifier for the link's context.
-        case `self`
-        
-        /// IANA – https://www.iana.org/assignments/link-relations/link-relations.xhtml
-        case publication
-        case collection
-        case previous
-        case next
-        
-        /// OPDS
-        case opdsFacet
-        
-        /// Extension or any other relation defined in the IANA link registry.
-        case other(String)
-        
-        public var rawValue: String {
-            switch self {
-            case .alternate: return "alternate"
-            case .contents: return "contents"
-            case .cover: return "cover"
-            case .manifest: return "manifest"
-            case .search: return "search"
-            case .self: return "self"
-                
-            case .publication: return "publication"
-            case .collection: return "collection"
-            case .previous: return "previous"
-            case .next: return "next"
-            
-            case .opdsFacet: return "http://opds-spec.org/facet"
-                
-            case .other(let value): return value
-            }
-        }
-        
-        public init(rawValue: String) {
-            switch rawValue.lowercased() {
-            case "alternate": self = .alternate
-            case "contents": self = .contents
-            case "cover": self = .cover
-            case "manifest": self = .manifest
-            case "search": self = .search
-            case "self": self = .self
-            
-            case "publication": self = .publication
-            case "collection": self = .collection
-            case "previous": self = .previous
-            case "next": self = .next
-                
-            case "http://opds-spec.org/facet": self = .opdsFacet
-                
-            default: self = .other(rawValue)
-            }
-        }
-        
-        public init(stringLiteral value: String) {
-            self.init(rawValue: value)
-        }
-        
-        public func hasPrefix(_ prefix: String) -> Bool {
-            return rawValue.hasPrefix(prefix)
-        }
-        
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(rawValue)
-        }
-        
-        public var hashValue: Int {
-            rawValue.hashValue
-        }
-    }
 
 }
 
@@ -302,12 +218,12 @@ extension Array where Element == Link {
     }
     
     /// Finds the first link with the given relation.
-    public func first(withRel rel: Link.Relation) -> Link? {
+    public func first(withRel rel: LinkRelation) -> Link? {
         return first { $0.rels.contains(rel) }
     }
 
     /// Finds all the links with the given relation.
-    public func filter(byRel rel: Link.Relation) -> [Link] {
+    public func filter(byRel rel: LinkRelation) -> [Link] {
         return filter { $0.rels.contains(rel) }
     }
     
@@ -387,27 +303,6 @@ extension Array where Element == Link {
     @available(*, deprecated, renamed: "firstIndex(withHREF:)")
     public func firstIndex(withHref href: String) -> Int? {
         return firstIndex(withHREF: href)
-    }
-    
-}
-
-
-extension Array where Element == Link.Relation {
-    
-    /// Parses multiple JSON relations into an array of Link.Relation.
-    public init(json: Any?) {
-        self.init()
-        
-        if let json = json as? String {
-            append(Link.Relation(rawValue: json))
-        } else if let json = json as? [String] {
-            let rels = json.compactMap { Link.Relation(rawValue: $0) }
-            append(contentsOf: rels)
-        }
-    }
-    
-    public var json: [String] {
-        map { $0.rawValue }
     }
     
 }

--- a/r2-shared-swift/Publication/LinkRelation.swift
+++ b/r2-shared-swift/Publication/LinkRelation.swift
@@ -1,0 +1,196 @@
+//
+//  Copyright 2020 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+/// Link relations as defined in https://readium.org/webpub-manifest/relationships.html
+public struct LinkRelation {
+    
+    /// The string representation of this link relation.
+    public let string: String
+    
+    public init(_ string: String) {
+        // > Registered relation type names MUST conform to the reg-rel-type rule
+        // > (see Section 3.3) and MUST be compared character by character in a
+        // > case-insensitive fashion.
+        // https://tools.ietf.org/html/rfc8288#section-2.1.1
+        self.string = string.lowercased()
+    }
+
+    public func hasPrefix(_ prefix: String) -> Bool {
+        return string.hasPrefix(prefix.lowercased())
+    }
+    
+    public var isSample: Bool {
+        self == .preview || self == .opdsAcquisitionSample
+    }
+    
+    public var isImage: Bool {
+        hasPrefix("http://opds-spec.org/image")
+    }
+    
+    public var isOPDSAcquisition: Bool {
+        hasPrefix("http://opds-spec.org/acquisition")
+    }
+
+    // MARK: - Known Link Relations
+    
+    /// Designates a substitute for the link's context.
+    public static let alternate = LinkRelation("alternate")
+    /// Refers to a table of contents.
+    public static let contents = LinkRelation("contents")
+    /// Refers to a publication's cover.
+    public static let cover = LinkRelation("cover")
+    /// Links to a manifest.
+    public static let manifest = LinkRelation("manifest")
+    /// Refers to a URI or templated URI that will perform a search.
+    public static let search = LinkRelation("search")
+    /// Conveys an identifier for the link's context.
+    public static let `self` = LinkRelation("self")
+    
+    // IANA – https://www.iana.org/assignments/link-relations/link-relations.xhtml
+    
+    /// Links to a publication manifest. A manifest represents structured information about a
+    /// publication, such as informative metadata, a list of resources, and a default reading order.
+    public static let publication = LinkRelation("publication")
+    /// The target IRI points to a resource which represents the collection resource for the
+    /// context IRI.
+    public static let collection = LinkRelation("collection")
+    /// Indicates that the link's context is a part of a series, and that the previous in the series
+    /// is the link target.
+    public static let previous = LinkRelation("previous")
+    /// Indicates that the link's context is a part of a series, and that the next in the series is
+    /// the link target.
+    public static let next = LinkRelation("next")
+    /// Refers to a resource that provides a preview of the link's context.
+    public static let preview = LinkRelation("preview")
+    
+    // OPDS – https://specs.opds.io/opds-1.2.html
+    
+    /// Fallback acquisition relation when no other relation is a good fit to express the nature
+    /// of the transaction.
+    public static let opdsAcquisition = LinkRelation("http://opds-spec.org/acquisition")
+    /// Indicates that a publication is freely accessible without any requirement, including
+    /// authentication.
+    public static let opdsAcquisitionOpenAccess = LinkRelation("http://opds-spec.org/acquisition/open-access")
+    /// Indicates that a publication can be borrowed for a limited period of time.
+    public static let opdsAcquisitionBorrow = LinkRelation("http://opds-spec.org/acquisition/borrow")
+    /// Indicates that a publication can be purchased for a given price.
+    public static let opdsAcquisitionBuy = LinkRelation("http://opds-spec.org/acquisition/buy")
+    /// Indicates that a sub-set of the full publication is freely accessible at a given URI,
+    /// without any prior requirement.
+    public static let opdsAcquisitionSample = LinkRelation("http://opds-spec.org/acquisition/sample")
+    /// Indicates that a publication be subscribed to, usually as part of a purchase and for a
+    /// limited period of time.
+    public static let opdsAcquisitionSubscribe = LinkRelation("http://opds-spec.org/acquisition/subscribe")
+    
+    /// A graphical Resource associated to the OPDS Catalog Entry.
+    public static let opdsImage = LinkRelation("http://opds-spec.org/image")
+    /// A reduced-size version of a graphical Resource associated to the OPS Catalog Entry.
+    public static let opdsImageThumbnail = LinkRelation("http://opds-spec.org/image/thumbnail")
+    
+    /// A Resource that includes a user’s existing set of Acquired Content, which may be
+    /// represented as an OPDS Catalog.
+    public static let opdsShelf = LinkRelation("http://opds-spec.org/shelf")
+    /// A Resource that includes a user’s set of subscriptions, which may be represented as an
+    /// OPDS Catalog.
+    public static let opdsSubscriptions = LinkRelation("http://opds-spec.org/subscriptions")
+    
+    /// An Acquisition Feed with a subset or an alternate order of the Publications listed.
+    public static let opdsFacet = LinkRelation("http://opds-spec.org/facet")
+    /// An Acquisition Feed with featured OPDS Catalog Entries. These Acquisition Feeds
+    /// typically contain a subset of the OPDS Catalog Entries in an OPDS Catalog that have been
+    /// selected for promotion by the OPDS Catalog provider. No order is implied.
+    public static let opdsFeatured = LinkRelation("http://opds-spec.org/featured")
+    /// An Acquisition Feed with recommended OPDS Catalog Entries. These Acquisition Feeds
+    /// typically contain a subset of the OPDS Catalog Entries in an OPDS Catalog that have been
+    /// selected specifically for the user.
+    public static let opdsRecommended = LinkRelation("http://opds-spec.org/recommended")
+    
+    /// An Acquisition Feed with newly released OPDS Catalog Entries. These Acquisition Feeds
+    /// typically contain a subset of the OPDS Catalog Entries in an OPDS Catalog based on the
+    /// publication date of the Publication.
+    public static let opdsSortNew = LinkRelation("http://opds-spec.org/sort/new")
+    /// An Acquisition Feed with popular OPDS Catalog Entries. These Acquisition Feeds typically
+    /// contain a subset of the OPDS Catalog Entries in an OPDS Catalog based on a numerical
+    /// ranking criteria.
+    public static let opdsSortPopular = LinkRelation("http://opds-spec.org/sort/popular")
+    
+    // Authentication for OPDS – https://drafts.opds.io/authentication-for-opds-1.0.html
+    
+    // Location where a client can authenticate the user with OAuth.
+    public static let opdsAuthenticate = LinkRelation("authenticate")
+    // Location where a client can refresh the Access Token by sending a Refresh Token.
+    public static let opdsRefresh = LinkRelation("refresh")
+    
+    // Logo associated to the Catalog provider.
+    public static let opdsLogo = LinkRelation("logo")
+    // Location where a user can register.
+    public static let opdsRegister = LinkRelation("register")
+    // Support resources for the user (either a website, an email or a telephone number).
+    public static let opdsHelp = LinkRelation("help")
+
+}
+
+extension LinkRelation: ExpressibleByStringLiteral {
+    
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+    
+}
+
+extension LinkRelation: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(string)
+    }
+    
+    public var hashValue: Int {
+        string.hashValue
+    }
+    
+}
+
+extension Array where Element == LinkRelation {
+    
+    /// Parses multiple JSON relations into an array of `LinkRelation`.
+    public init(json: Any?) {
+        self.init()
+        
+        if let json = json as? String {
+            append(LinkRelation(json))
+        } else if let json = json as? [String] {
+            let rels = json.compactMap { LinkRelation($0) }
+            append(contentsOf: rels)
+        }
+    }
+    
+    public var json: [String] {
+        map { $0.string }
+    }
+    
+    public func contains(_ other: String) -> Bool {
+        contains(LinkRelation(other))
+    }
+
+    public func containsAny(_ others: [LinkRelation]) -> Bool {
+        contains(where: { others.contains($0) })
+    }
+
+    public func containsAny(_ others: LinkRelation...) -> Bool {
+        containsAny(others)
+    }
+
+    public func containsAny(_ others: [String]) -> Bool {
+        containsAny(others.map { LinkRelation($0) })
+    }
+
+    public func containsAny(_ others: String...) -> Bool {
+        containsAny(others)
+    }
+    
+}

--- a/r2-shared-swift/Publication/Manifest.swift
+++ b/r2-shared-swift/Publication/Manifest.swift
@@ -104,14 +104,14 @@ public struct Manifest: JSONEquatable {
     }
     
     /// Finds the first link with the given relation in the manifest's links.
-    public func link(withRel rel: Link.Relation) -> Link? {
+    public func link(withRel rel: LinkRelation) -> Link? {
         return readingOrder.first(withRel: rel)
             ?? resources.first(withRel: rel)
             ?? links.first(withRel: rel)
     }
     
     /// Finds all the links with the given relation in the manifest's links.
-    public func links(withRel rel: Link.Relation) -> [Link] {
+    public func links(withRel rel: LinkRelation) -> [Link] {
         return (readingOrder + resources + links).filter(byRel: rel)
     }
 

--- a/r2-shared-swift/Publication/Manifest.swift
+++ b/r2-shared-swift/Publication/Manifest.swift
@@ -114,5 +114,26 @@ public struct Manifest: JSONEquatable {
     public func links(withRel rel: LinkRelation) -> [Link] {
         return (readingOrder + resources + links).filter(byRel: rel)
     }
+    
+    /// Makes a copy of the `Manifest`, after modifying some of its properties.
+    public func copy(
+        context: [String]? = nil,
+        metadata: Metadata? = nil,
+        links: [Link]? = nil,
+        readingOrder: [Link]? = nil,
+        resources: [Link]? = nil,
+        tableOfContents: [Link]? = nil,
+        subcollections: [String: [PublicationCollection]]? = nil
+    ) -> Manifest {
+        Manifest(
+            context: context ?? self.context,
+            metadata: metadata ?? self.metadata,
+            links: links ?? self.links,
+            readingOrder: readingOrder ?? self.readingOrder,
+            resources: resources ?? self.resources,
+            tableOfContents: tableOfContents ?? self.tableOfContents,
+            subcollections: subcollections ?? self.subcollections
+        )
+    }
 
 }

--- a/r2-shared-swift/Publication/Publication+Deprecated.swift
+++ b/r2-shared-swift/Publication/Publication+Deprecated.swift
@@ -263,7 +263,7 @@ extension Link {
     public var typeLink: String? { type }
     
     @available(*, deprecated, renamed: "rels")
-    public var rel: [String] { rels.map { $0.rawValue } }
+    public var rel: [String] { rels.map(\.string) }
     
     @available(*, deprecated, renamed: "href")
     public var absoluteHref: String? { href }

--- a/r2-shared-swift/Publication/Publication.swift
+++ b/r2-shared-swift/Publication/Publication.swift
@@ -122,12 +122,12 @@ public class Publication: Loggable {
     }
     
     /// Finds the first link with the given relation in the publication's links.
-    public func link(withRel rel: Link.Relation) -> Link? {
+    public func link(withRel rel: LinkRelation) -> Link? {
         return manifest.link(withRel: rel)
     }
     
     /// Finds all the links with the given relation in the publication's links.
-    public func links(withRel rel: Link.Relation) -> [Link] {
+    public func links(withRel rel: LinkRelation) -> [Link] {
         return manifest.links(withRel: rel)
     }
 

--- a/r2-shared-swiftTests/Publication/ManifestTests.swift
+++ b/r2-shared-swiftTests/Publication/ManifestTests.swift
@@ -340,6 +340,56 @@ class ManifestTests: XCTestCase {
             []
         )
     }
+    
+    func testCopy() {
+        let manifest = Manifest(
+            context: ["https://readium.org/webpub-manifest/context.jsonld"],
+            metadata: Metadata(title: "Title"),
+            links: [Link(href: "/manifest.json", rels: [.self])],
+            readingOrder: [Link(href: "/chap1.html", type: "text/html")],
+            resources: [Link(href: "/image.png", type: "image/png")],
+            tableOfContents: [Link(href: "/cover.html"), Link(href: "/chap1.html")],
+            subcollections: ["sub": [PublicationCollection(links: [Link(href: "/sublink")])]]
+        )
+
+        AssertJSONEqual(manifest.json, manifest.copy().json)
+        
+        let copy = manifest.copy(
+            context: ["copy-context"],
+            metadata: Metadata(title: "copy-title"),
+            links: [Link(href: "copy-links")],
+            readingOrder: [Link(href: "copy-reading-order")],
+            resources: [Link(href: "copy-resources")],
+            tableOfContents: [Link(href: "copy-toc")],
+            subcollections: ["copy": [PublicationCollection(links: [])]]
+        )
+
+        AssertJSONEqual(
+            copy.json,
+            [
+                "@context": ["copy-context"],
+                "metadata": [
+                    "title": "copy-title",
+                    "readingProgression": "auto"
+                ],
+                "links": [
+                    ["href": "copy-links", "templated": false]
+                ],
+                "readingOrder": [
+                    ["href": "copy-reading-order", "templated": false]
+                ],
+                "resources": [
+                    ["href": "copy-resources", "templated": false]
+                ],
+                "toc": [
+                    ["href": "copy-toc", "templated": false]
+                ],
+                "copy": [
+                    "links": []
+                ]
+            ]
+        )
+    }
 
     private func makeManifest(metadata: Metadata = Metadata(title: ""), links: [Link] = [], readingOrder: [Link] = [], resources: [Link] = []) -> Manifest {
         return Manifest(metadata: metadata, links: links, readingOrder: readingOrder, resources: resources)


### PR DESCRIPTION
* Use a `struct` instead of `enum` for `LinkRelation`, to be more opened to extensions.
* Add missing link relations from OPDS specs.