### PR TITLE
Add LocatorService

### DIFF
--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		CA62B37C24E02F7C0046CDCF /* TransformingResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA62B37B24E02F7C0046CDCF /* TransformingResource.swift */; };
 		CA62B37E24E02FA30046CDCF /* LazyResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA62B37D24E02FA30046CDCF /* LazyResource.swift */; };
 		CA62B38024E030C00046CDCF /* CachingResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA62B37F24E030C00046CDCF /* CachingResource.swift */; };
+		CA6511742588BC0E007C1C9E /* LocatorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6511722588BC0E007C1C9E /* LocatorService.swift */; };
+		CA6511752588BC0E007C1C9E /* DefaultLocatorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6511732588BC0E007C1C9E /* DefaultLocatorService.swift */; };
 		CA68BDCE24407750009A6BAA /* StringEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA68BDCD24407750009A6BAA /* StringEncoding.swift */; };
 		CA6D42672404370C002FBED4 /* OPDSHolds.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6D42662404370C002FBED4 /* OPDSHolds.swift */; };
 		CA6D42692404381B002FBED4 /* OPDSHoldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6D42682404381B002FBED4 /* OPDSHoldsTests.swift */; };
@@ -290,6 +292,8 @@
 		CA62B37B24E02F7C0046CDCF /* TransformingResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformingResource.swift; sourceTree = "<group>"; };
 		CA62B37D24E02FA30046CDCF /* LazyResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyResource.swift; sourceTree = "<group>"; };
 		CA62B37F24E030C00046CDCF /* CachingResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingResource.swift; sourceTree = "<group>"; };
+		CA6511722588BC0E007C1C9E /* LocatorService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocatorService.swift; sourceTree = "<group>"; };
+		CA6511732588BC0E007C1C9E /* DefaultLocatorService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLocatorService.swift; sourceTree = "<group>"; };
 		CA68BDCD24407750009A6BAA /* StringEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringEncoding.swift; sourceTree = "<group>"; };
 		CA6D42662404370C002FBED4 /* OPDSHolds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSHolds.swift; sourceTree = "<group>"; };
 		CA6D42682404381B002FBED4 /* OPDSHoldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSHoldsTests.swift; sourceTree = "<group>"; };
@@ -726,6 +730,15 @@
 			path = Resource;
 			sourceTree = "<group>";
 		};
+		CA6511712588BC0E007C1C9E /* Locator */ = {
+			isa = PBXGroup;
+			children = (
+				CA6511722588BC0E007C1C9E /* LocatorService.swift */,
+				CA6511732588BC0E007C1C9E /* DefaultLocatorService.swift */,
+			);
+			path = Locator;
+			sourceTree = "<group>";
+		};
 		CA68BDCC24407745009A6BAA /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -801,6 +814,7 @@
 				CA9FC07524825A880020B9CC /* PublicationServicesBuilder.swift */,
 				CA2B6B5724C0A868007AF537 /* Content Protection */,
 				CACDE5FA24851620006FEB1B /* Cover */,
+				CA6511712588BC0E007C1C9E /* Locator */,
 				CACDE5F92485161A006FEB1B /* Positions */,
 			);
 			path = Services;
@@ -1225,6 +1239,7 @@
 				CAC34F0C221C61BD002C452E /* DRM+Deprecated.swift in Sources */,
 				CA62B38024E030C00046CDCF /* CachingResource.swift in Sources */,
 				CA3386E42404FD0300FDCBBA /* Properties+Encryption.swift in Sources */,
+				CA6511742588BC0E007C1C9E /* LocatorService.swift in Sources */,
 				CA9FC06F24824C3B0020B9CC /* Manifest.swift in Sources */,
 				CA8C841A24689E4000CE97A4 /* RoutingFetcher.swift in Sources */,
 				CA5F8EE92404035D00926120 /* ReadingProgression.swift in Sources */,
@@ -1262,6 +1277,7 @@
 				3ED94ADFB10A3028249246DB /* MediaTypeSnifferContent.swift in Sources */,
 				3ED947E4B657163DB35B4874 /* MediaType.swift in Sources */,
 				3ED94588C74689AF63D0B13E /* MediaType+Deprecated.swift in Sources */,
+				CA6511752588BC0E007C1C9E /* DefaultLocatorService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/r2-shared-swift/Publication/Locator.swift
+++ b/r2-shared-swift/Publication/Locator.swift
@@ -102,12 +102,29 @@ public struct Locator: Hashable, CustomStringConvertible, Loggable {
     }
     
     /// Makes a copy of the `Locator`, after modifying some of its components.
-    public func copy(title: String?? = nil, locations transformLocations: ((inout Locations) -> Void)? = nil, text transformText: ((inout Text) -> Void)? = nil) -> Locator {
+    public func copy(href: String? = nil, type: String? = nil, title: String?? = nil, locations transformLocations: ((inout Locations) -> Void)? = nil, text transformText: ((inout Text) -> Void)? = nil) -> Locator {
         var locations = self.locations
         var text = self.text
         transformLocations?(&locations)
         transformText?(&text)
-        return Locator(href: href, type: type, title: title ?? self.title, locations: locations, text: text)
+        return Locator(
+            href: href ?? self.href,
+            type: type ?? self.type,
+            title: title ?? self.title,
+            locations: locations,
+            text: text
+        )
+    }
+    
+    /// Makes a copy of the `Locator`, after modifying some of its components.
+    public func copy(href: String? = nil, type: String? = nil, title: String?? = nil, locations: Locations? = nil, text: Text? = nil) -> Locator {
+        Locator(
+            href: href ?? self.href,
+            type: type ?? self.type,
+            title: title ?? self.title,
+            locations: locations ?? self.locations,
+            text: text ?? self.text
+        )
     }
 
     /// One or more alternative expressions of the location.

--- a/r2-shared-swift/Publication/Services/Locator/DefaultLocatorService.swift
+++ b/r2-shared-swift/Publication/Services/Locator/DefaultLocatorService.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright 2020 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+open class DefaultLocatorService: LocatorService {
+    
+    let readingOrder: [Link]
+    
+    public init(readingOrder: [Link]) {
+        self.readingOrder = readingOrder
+    }
+    
+    open func locate(_ locator: Locator) -> Locator? {
+        guard readingOrder.firstIndex(withHREF: locator.href) != nil else {
+            return nil
+        }
+        
+        return locator
+    }
+    
+    open func locate(progression: Double) -> Locator? { nil }
+    
+}

--- a/r2-shared-swift/Publication/Services/Locator/LocatorService.swift
+++ b/r2-shared-swift/Publication/Services/Locator/LocatorService.swift
@@ -1,0 +1,62 @@
+//
+//  Copyright 2020 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+public typealias LocatorServiceFactory = (PublicationServiceContext) -> LocatorService?
+
+/// Locates the destination of various sources (e.g. locators, progression, etc.) in the
+/// publication.
+///
+/// This service can be used to implement a variety of features, such as:
+///   - Jumping to a given position or total progression, by converting it first to a `Locator`.
+///   - Converting a `Locator` which was created from an alternate manifest with a different reading
+///     order. For example, when downloading a streamed manifest or offloading a package.
+public protocol LocatorService: PublicationService {
+    
+    /// Locates the target of the given `locator`.
+    func locate(_ locator: Locator) -> Locator?
+    
+    /// Locates the target at the given `progression` relative to the whole publication.
+    func locate(progression: Double) -> Locator?
+    
+}
+
+
+// MARK: Publication Helpers
+
+public extension Publication {
+    
+    /// Locates the target of the given `locator`.
+    ///
+    /// If `locator.href` can be found in the reading order, `locator` will be returned directly.
+    /// Otherwise, will attempt to find the closest match using `totalProgression`, `position`,
+    /// `fragments`, etc.
+    func locate(_ locator: Locator) -> Locator? {
+        findService(LocatorService.self)?.locate(locator)
+    }
+    
+    /// Locates the target at the given `progression` relative to the whole publication.
+    func locate(progression: Double) -> Locator? {
+        findService(LocatorService.self)?.locate(progression: progression)
+    }
+
+}
+
+
+// MARK: PublicationServicesBuilder Helpers
+
+public extension PublicationServicesBuilder {
+    
+    mutating func setLocatorServiceFactory(_ factory: LocatorServiceFactory?) {
+        if let factory = factory {
+            set(LocatorService.self, factory)
+        } else {
+            remove(LocatorService.self)
+        }
+    }
+
+}

--- a/r2-shared-swift/Publication/Services/PublicationServicesBuilder.swift
+++ b/r2-shared-swift/Publication/Services/PublicationServicesBuilder.swift
@@ -18,27 +18,25 @@ public struct PublicationServicesBuilder {
     
     private var factories: [String: PublicationServiceFactory] = [:]
 
-    public init(setup: ((inout PublicationServicesBuilder) -> Void)? = nil) {
-        setup?(&self)
-    }
-    
     public init(
         contentProtection: ContentProtectionServiceFactory? = nil,
         cover: CoverServiceFactory? = nil,
-        positions: PositionsServiceFactory? = nil
+        locator: LocatorServiceFactory? = { DefaultLocatorService(readingOrder: $0.manifest.readingOrder) },
+        positions: PositionsServiceFactory? = nil,
+        setup: (inout PublicationServicesBuilder) -> Void = { _ in }
     ) {
-        self.init {
-            $0.setContentProtectionServiceFactory(contentProtection)
-            $0.setCoverServiceFactory(cover)
-            $0.setPositionsServiceFactory(positions)
-        }
+        setContentProtectionServiceFactory(contentProtection)
+        setCoverServiceFactory(cover)
+        setLocatorServiceFactory(locator)
+        setPositionsServiceFactory(positions)
+        setup(&self)
     }
 
     /// Builds the actual list of publication services to use in a `Publication`.
     ///
     /// - Parameter context: Context provided to the service factories.
     public func build(context: PublicationServiceContext) -> [PublicationService] {
-        return factories.values.compactMap { $0(context) }
+        factories.values.compactMap { $0(context) }
     }
 
     /// Sets the publication service factory for the given service type.

--- a/r2-shared-swiftTests/Publication/PublicationTests.swift
+++ b/r2-shared-swiftTests/Publication/PublicationTests.swift
@@ -232,9 +232,9 @@ class PublicationTests: XCTestCase {
                     return FailureResource(link: $0, error: .notFound)
                 }
             },
-            services: .init {
+            services: PublicationServicesBuilder(setup: {
                 $0.set(TestService.self) { _ in TestService(link: link) }
-            }
+            })
         )
         
         XCTAssertEqual(publication.get(link).readAsString().getOrNil(), "world")

--- a/r2-shared-swiftTests/Publication/Services/PublicationServicesBuilderTests.swift
+++ b/r2-shared-swiftTests/Publication/Services/PublicationServicesBuilderTests.swift
@@ -35,7 +35,7 @@ class PublicationServicesBuilderTests: XCTestCase {
 
         let services = builder.build(context: context)
         
-        XCTAssert(services.count == 2)
+        XCTAssert(services.count == 3)
         XCTAssert(services.contains { $0 is CoverService })
         XCTAssert(services.contains { $0 is PositionsService })
     }
@@ -47,15 +47,16 @@ class PublicationServicesBuilderTests: XCTestCase {
 
         let services = builder.build(context: context)
 
-        XCTAssert(services.count == 2)
+        XCTAssert(services.count == 3)
         XCTAssert(services.contains { $0 is FooServiceA })
         XCTAssert(services.contains { $0 is BarServiceA })
     }
     
-    func testBuildEmpty() {
+    func testBuildDefault() {
         let builder = PublicationServicesBuilder()
         let services = builder.build(context: context)
-        XCTAssertEqual(services.count, 0)
+        XCTAssertEqual(services.count, 1)
+        XCTAssert(services.contains { $0 is DefaultLocatorService })
     }
     
     func testSetOverwrite() {
@@ -65,7 +66,6 @@ class PublicationServicesBuilderTests: XCTestCase {
 
         let services = builder.build(context: context)
         
-        XCTAssert(services.count == 1)
         XCTAssert(services.contains { $0 is FooServiceB })
     }
     
@@ -77,8 +77,8 @@ class PublicationServicesBuilderTests: XCTestCase {
         builder.remove(FooService.self)
         
         let services = builder.build(context: context)
-        XCTAssert(services.count == 1)
         XCTAssert(services.contains { $0 is BarServiceA })
+        XCTAssert(!services.contains { $0 is FooServiceA })
     }
     
     func testRemoveUnknown() {
@@ -88,7 +88,6 @@ class PublicationServicesBuilderTests: XCTestCase {
         builder.remove(BarService.self)
         
         let services = builder.build(context: context)
-        XCTAssert(services.count == 1)
         XCTAssert(services.contains { $0 is FooServiceA })
     }
     
@@ -102,7 +101,6 @@ class PublicationServicesBuilderTests: XCTestCase {
         }
         
         let services = builder.build(context: context)
-        XCTAssert(services.count == 2)
         XCTAssert(services.contains { ($0 as? FooServiceC)?.wrapped is FooServiceB })
         XCTAssert(services.contains { $0 is BarServiceA })
     }


### PR DESCRIPTION
Locates the destination of various sources (e.g. locators, progression, etc.) in the publication.

This service is a building block to implement a variety of features, such as:
* Jumping to a given position or total progression, by converting it first to a `Locator`.
* Converting a `Locator` which was created from an alternate manifest with a different reading order. For example, when downloading a streamed manifest or offloading a package.