### PR TITLE
Add LocatorService.locate(progression:) and access to the Publication in the Publication Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * `PublicationServiceContext` now holds a weak reference to the parent `Publication`. This can be used to access other services from a given `PublicationService` implementation.
+* The default `LocatorService` implementation can be used to get a `Locator` from a global progression in the publication.
+    * `publication.locate(progression: 0.5)`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* `PublicationServiceContext` now holds a weak reference to the parent `Publication`. This can be used to access other services from a given `PublicationService` implementation.
+
 ### Changed
 
 * CocoaPods is not supported anymore.

--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		CA9FC07624825A880020B9CC /* PublicationServicesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9FC07524825A880020B9CC /* PublicationServicesBuilder.swift */; };
 		CA9FC0792482657F0020B9CC /* PublicationServicesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9FC0782482657F0020B9CC /* PublicationServicesBuilderTests.swift */; };
 		CAAF80CA2456D7370024D7AE /* AudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAF80C92456D7370024D7AE /* AudioSession.swift */; };
+		CAB009DC25B19811002E79E4 /* Weak.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB009DB25B19811002E79E4 /* Weak.swift */; };
 		CAB88C92224E766E00D36C99 /* LocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB88C91224E766E00D36C99 /* LocatorTests.swift */; };
 		CABBB2E52237ADEB004EB039 /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B1879F1FA33D4D00BB46BF /* Feed.swift */; };
 		CABBB2E62237ADEB004EB039 /* OpdsMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B187A31FA33E1D00BB46BF /* OpdsMetadata.swift */; };
@@ -343,6 +344,7 @@
 		CA9FC0782482657F0020B9CC /* PublicationServicesBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationServicesBuilderTests.swift; sourceTree = "<group>"; };
 		CAAABA9F24D7F2DC004A4466 /* URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLTests.swift; sourceTree = "<group>"; };
 		CAAF80C92456D7370024D7AE /* AudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSession.swift; sourceTree = "<group>"; };
+		CAB009DB25B19811002E79E4 /* Weak.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weak.swift; sourceTree = "<group>"; };
 		CAB88C91224E766E00D36C99 /* LocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorTests.swift; sourceTree = "<group>"; };
 		CABBB2F32237BF42004EB039 /* OPDSPriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSPriceTests.swift; sourceTree = "<group>"; };
 		CABBB2F52237BF61004EB039 /* OPDSPrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSPrice.swift; sourceTree = "<group>"; };
@@ -484,6 +486,7 @@
 				CA038E4F25222B0900489729 /* ControlFlow.swift */,
 				CA7B1AA4248A2CFF00152F73 /* URITemplate.swift */,
 				CA7116F02455FAF900C029FD /* UTI.swift */,
+				CAB009DB25B19811002E79E4 /* Weak.swift */,
 				3ED94B721E98E44B73A50CCB /* Media Type */,
 			);
 			path = Toolkit;
@@ -1227,6 +1230,7 @@
 				CABEB3DC2215698600090B6C /* Deferred.swift in Sources */,
 				CA6F27702469D9050065B405 /* ArchiveFetcher.swift in Sources */,
 				CA3386EA24052D8B00FDCBBA /* DOMRange.swift in Sources */,
+				CAB009DC25B19811002E79E4 /* Weak.swift in Sources */,
 				CA2006512225A1F300E6B3BD /* Observable.swift in Sources */,
 				CA62B37C24E02F7C0046CDCF /* TransformingResource.swift in Sources */,
 				CA038E5025222B0900489729 /* ControlFlow.swift in Sources */,

--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3ED945A0DC573E0A631BE9CA /* BufferedResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED946C593463CDA73661EEE /* BufferedResource.swift */; };
 		3ED9461016FE3D038159215B /* MediaTypeSnifferContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED9440B6F078846EA92DB02 /* MediaTypeSnifferContext.swift */; };
 		3ED947E4B657163DB35B4874 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED943C9821500DFBB7F13EE /* MediaType.swift */; };
+		3ED94848B32DF039C951C7E4 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED942B2BBE9224BBDB9CDEE /* Collection.swift */; };
 		3ED948EA4CA3AC044791A128 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED944F337D9B6CFC6CD33EA /* MediaTypeTests.swift */; };
 		3ED949F0680354B76F0A9772 /* MediaTypeSniffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED94693F7D849969088AA77 /* MediaTypeSniffer.swift */; };
 		3ED94A40717F97D2AC2A70A2 /* BufferedResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED945F9EAD92BCC3422D80D /* BufferedResourceTests.swift */; };
@@ -58,6 +59,7 @@
 		CA228D1F24BDDDAF00879E2E /* CancellableResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA228D1E24BDDDAF00879E2E /* CancellableResult.swift */; };
 		CA252DD92447A3740005067C /* Minizip.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA252DD82447A3740005067C /* Minizip.swift */; };
 		CA252DE12447A5C00005067C /* Archive+ZIPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA252DE02447A5C00005067C /* Archive+ZIPTests.swift */; };
+		CA255AB225B1A3B4000D87AF /* DefaultLocatorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA255AB125B1A3B4000D87AF /* DefaultLocatorServiceTests.swift */; };
 		CA2AE320221C1DCB008BD18F /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2AE31D221C1DCB008BD18F /* Logger.swift */; };
 		CA2AE321221C1DCB008BD18F /* LoggerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2AE31E221C1DCB008BD18F /* LoggerStub.swift */; };
 		CA2AE322221C1DCB008BD18F /* Loggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2AE31F221C1DCB008BD18F /* Loggable.swift */; };
@@ -212,6 +214,7 @@
 		0318F709221DD4CA004E5114 /* Locator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locator.swift; sourceTree = "<group>"; };
 		3ED9404DDFEB701146894979 /* MediaTypeSnifferTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTypeSnifferTests.swift; sourceTree = "<group>"; };
 		3ED941F913B58D61AE98A6CC /* UInt64.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UInt64.swift; sourceTree = "<group>"; };
+		3ED942B2BBE9224BBDB9CDEE /* Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		3ED943C9821500DFBB7F13EE /* MediaType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
 		3ED9440B6F078846EA92DB02 /* MediaTypeSnifferContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTypeSnifferContext.swift; sourceTree = "<group>"; };
 		3ED944F337D9B6CFC6CD33EA /* MediaTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTypeTests.swift; sourceTree = "<group>"; };
@@ -262,6 +265,7 @@
 		CA252DD82447A3740005067C /* Minizip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Minizip.swift; sourceTree = "<group>"; };
 		CA252DDA2447A3810005067C /* Minizip.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Minizip.framework; path = Carthage/Build/iOS/Minizip.framework; sourceTree = "<group>"; };
 		CA252DE02447A5C00005067C /* Archive+ZIPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+ZIPTests.swift"; sourceTree = "<group>"; };
+		CA255AB125B1A3B4000D87AF /* DefaultLocatorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLocatorServiceTests.swift; sourceTree = "<group>"; };
 		CA2AE31D221C1DCB008BD18F /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		CA2AE31E221C1DCB008BD18F /* LoggerStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerStub.swift; sourceTree = "<group>"; };
 		CA2AE31F221C1DCB008BD18F /* Loggable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Loggable.swift; sourceTree = "<group>"; };
@@ -470,6 +474,7 @@
 				CA68BDCC24407745009A6BAA /* Extensions */,
 				CA228D1724BCE26000879E2E /* Logging */,
 				CA81741A24585E5800033776 /* Media */,
+				3ED94B721E98E44B73A50CCB /* Media Type */,
 				CA0D3C0D2518E1F9005B47BC /* PDF */,
 				CA60CE1E2446DE7500149B22 /* XML */,
 				CA228D1E24BDDDAF00879E2E /* CancellableResult.swift */,
@@ -487,7 +492,6 @@
 				CA7B1AA4248A2CFF00152F73 /* URITemplate.swift */,
 				CA7116F02455FAF900C029FD /* UTI.swift */,
 				CAB009DB25B19811002E79E4 /* Weak.swift */,
-				3ED94B721E98E44B73A50CCB /* Media Type */,
 			);
 			path = Toolkit;
 			sourceTree = "<group>";
@@ -618,6 +622,14 @@
 				CAE4DCA124B8CD3E00611638 /* ExplodedArchiveTests.swift */,
 			);
 			path = Archive;
+			sourceTree = "<group>";
+		};
+		CA255AB025B1A385000D87AF /* Locator */ = {
+			isa = PBXGroup;
+			children = (
+				CA255AB125B1A3B4000D87AF /* DefaultLocatorServiceTests.swift */,
+			);
+			path = Locator;
 			sourceTree = "<group>";
 		};
 		CA2AE31C221C1DCB008BD18F /* Logger */ = {
@@ -795,6 +807,7 @@
 				CACDE5D62483AAB0006FEB1B /* UIImage.swift */,
 				CA1AB0C324E2D0EA00004BC0 /* URL.swift */,
 				3ED941F913B58D61AE98A6CC /* UInt64.swift */,
+				3ED942B2BBE9224BBDB9CDEE /* Collection.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -871,6 +884,7 @@
 				CA9FC0782482657F0020B9CC /* PublicationServicesBuilderTests.swift */,
 				CA62B36F24DFF3C70046CDCF /* Content Protection */,
 				CAE4DCB024BB668F00611638 /* Cover */,
+				CA255AB025B1A385000D87AF /* Locator */,
 				CACDE60124851681006FEB1B /* Positions */,
 			);
 			path = Services;
@@ -1129,6 +1143,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA255AB225B1A3B4000D87AF /* DefaultLocatorServiceTests.swift in Sources */,
 				CABBB2F42237BF42004EB039 /* OPDSPriceTests.swift in Sources */,
 				CACD75E42236A0F0004F20CA /* SubjectTests.swift in Sources */,
 				CA6D426D240439F4002FBED4 /* OPDSCopiesTests.swift in Sources */,
@@ -1304,6 +1319,7 @@
 				3ED94B0E57C3968107287D9B /* FileAsset.swift in Sources */,
 				3ED945A0DC573E0A631BE9CA /* BufferedResource.swift in Sources */,
 				3ED942E5B5E4E04950D8FB17 /* UInt64.swift in Sources */,
+				3ED94848B32DF039C951C7E4 /* Collection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/r2-shared-swift/Publication/Publication.swift
+++ b/r2-shared-swift/Publication/Publication.swift
@@ -52,8 +52,16 @@ public class Publication: Loggable {
         format: Format = .unknown,
         formatVersion: String? = nil
     ) {
+        let weakPublication = Weak<Publication>()
+
         var manifest = manifest
-        let services = servicesBuilder.build(context: .init(manifest: manifest, fetcher: fetcher))
+        let services = servicesBuilder.build(
+            context: PublicationServiceContext(
+                publication: weakPublication,
+                manifest: manifest,
+                fetcher: fetcher
+            )
+        )
         manifest.links.append(contentsOf: services.flatMap { $0.links })
         
         self.manifest = manifest
@@ -61,6 +69,8 @@ public class Publication: Loggable {
         self.services = services
         self.format = format
         self.formatVersion = formatVersion
+
+        weakPublication.ref = self
     }
     
     /// Parses a Readium Web Publication Manifest.

--- a/r2-shared-swift/Publication/Services/Locator/DefaultLocatorService.swift
+++ b/r2-shared-swift/Publication/Services/Locator/DefaultLocatorService.swift
@@ -6,14 +6,21 @@
 
 import Foundation
 
-open class DefaultLocatorService: LocatorService {
+/// A default implementation of the `LocatorService` using the `PositionsService` to locate its inputs.
+open class DefaultLocatorService: LocatorService, Loggable {
     
     let readingOrder: [Link]
+    let positionsByReadingOrder: () -> [[Locator]]
     
-    public init(readingOrder: [Link]) {
+    public init(readingOrder: [Link], positionsByReadingOrder: @escaping () -> [[Locator]]) {
         self.readingOrder = readingOrder
+        self.positionsByReadingOrder = positionsByReadingOrder
     }
-    
+
+    public convenience init(readingOrder: [Link], publication: Weak<Publication>) {
+        self.init(readingOrder: readingOrder, positionsByReadingOrder: { publication()?.positionsByReadingOrder ?? [] })
+    }
+
     open func locate(_ locator: Locator) -> Locator? {
         guard readingOrder.firstIndex(withHREF: locator.href) != nil else {
             return nil
@@ -22,6 +29,100 @@ open class DefaultLocatorService: LocatorService {
         return locator
     }
     
-    open func locate(progression: Double) -> Locator? { nil }
-    
+    open func locate(progression totalProgression: Double) -> Locator? {
+        guard 0.0...1.0 ~= totalProgression else {
+            log(.error, "Progression must be between 0.0 and 1.0, received \(totalProgression)")
+            return nil
+        }
+
+        let positions = positionsByReadingOrder()
+        guard let (readingOrderIndex, position) = findClosest(to: totalProgression, in: positions) else {
+            return nil
+        }
+
+        return position.copy(locations: {
+            $0.totalProgression = totalProgression
+
+            if let progression = self.resourceProgression(for: totalProgression, in: positions, readingOrderIndex: readingOrderIndex) {
+                $0.progression = progression
+            }
+        })
+    }
+
+    /// Computes the progression relative to a reading order resource at the given index, from its `totalProgression`
+    /// relative to the whole publication.
+    private func resourceProgression(for totalProgression: Double, in positions: [[Locator]], readingOrderIndex: Int) -> Double? {
+        guard let startProgression = positions[readingOrderIndex].first?.locations.totalProgression else {
+            return nil
+        }
+        let endProgression = positions.getOrNil(readingOrderIndex + 1)?.first?.locations.totalProgression ?? 1.0
+
+        if totalProgression <= startProgression {
+            return 0.0
+        } else if totalProgression >= endProgression {
+            return 1.0
+        } else {
+            return (totalProgression - startProgression) / (endProgression - startProgression)
+        }
+    }
+
+    /// Finds the [Locator] in the given `positions` which is the closest to the given `totalProgression`, without
+    /// exceeding it.
+    private func findClosest(to totalProgression: Double, in positions: [[Locator]]) -> (readingOrderIndex: Int, position: Locator)? {
+        guard let lastPosition = findLast(in: positions) else {
+            return nil
+        }
+
+        if let lastProgression = lastPosition.item.locations.totalProgression, totalProgression >= lastProgression {
+            return (readingOrderIndex: lastPosition.index.x, position: lastPosition.item)
+        }
+
+        func inBetween(_ first: Locator, _ second: Locator) -> Bool {
+            if
+                let prog1 = first.locations.totalProgression,
+                let prog2 = second.locations.totalProgression,
+                prog1..<prog2 ~= totalProgression
+            {
+                return true
+            }
+            return false
+        }
+
+        guard let position = findFirstByPair(in: positions, where: inBetween) else {
+            return nil
+        }
+        return (readingOrderIndex: position.index.x, position: position.item)
+    }
+
+    /// Holds an item and its position in a two-dimensional array.
+    private typealias Match<T> = (index: (x: Int, y: Int), item: T)
+
+    /// Finds the first item matching the given condition when paired with its successor.
+    private func findFirstByPair<T>(in items: [[T]], where condition: (T, T) -> Bool) -> Match<T>? {
+        var previous: Match<T>? = nil
+
+        for (x, section) in items.enumerated() {
+            for (y, item) in section.enumerated() {
+                if let previous = previous, condition(previous.item, item) {
+                    return previous
+                }
+                previous = ((x, y), item)
+            }
+        }
+
+        return nil
+    }
+
+    /// Finds the last item in the last non-empty list of `items`.
+    private func findLast<T>(in items: [[T]]) -> Match<T>? {
+        var last: Match<T>? = nil
+
+        for (x, section) in items.enumerated() {
+            for (y, item) in section.enumerated() {
+                last = ((x, y), item)
+            }
+        }
+        return last
+    }
+
 }

--- a/r2-shared-swift/Publication/Services/PublicationService.swift
+++ b/r2-shared-swift/Publication/Services/PublicationService.swift
@@ -1,12 +1,7 @@
 //
-//  PublicationService.swift
-//  r2-shared-swift
-//
-//  Created by Mickaël Menu on 30/05/2020.
-//
 //  Copyright 2020 Readium Foundation. All rights reserved.
-//  Use of this source code is governed by a BSD-style license which is detailed
-//  in the LICENSE file present in the project repository where this source code is maintained.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
 //
 
 import Foundation
@@ -61,6 +56,16 @@ public typealias PublicationServiceFactory = (PublicationServiceContext) -> Publ
 
 /// Container for the context from which a service is created.
 public struct PublicationServiceContext {
+
+    /// Weak reference to the parent publication.
+    ///
+    /// Don't store directly the referenced publication, always access it through the `Weak` property.
+    ///
+    /// The publication won't be set when the service is created or when calling `PublicationService.links`, but you can
+    /// use it during regular service operations. If you need to initialize your service differently depending on the
+    /// publication, use `manifest`.
+    public let publication: Weak<Publication>
+
     public let manifest: Manifest
     public let fetcher: Fetcher
 }

--- a/r2-shared-swift/Publication/Services/PublicationServicesBuilder.swift
+++ b/r2-shared-swift/Publication/Services/PublicationServicesBuilder.swift
@@ -21,7 +21,7 @@ public struct PublicationServicesBuilder {
     public init(
         contentProtection: ContentProtectionServiceFactory? = nil,
         cover: CoverServiceFactory? = nil,
-        locator: LocatorServiceFactory? = { DefaultLocatorService(readingOrder: $0.manifest.readingOrder) },
+        locator: LocatorServiceFactory? = { DefaultLocatorService(readingOrder: $0.manifest.readingOrder, publication: $0.publication) },
         positions: PositionsServiceFactory? = nil,
         setup: (inout PublicationServicesBuilder) -> Void = { _ in }
     ) {

--- a/r2-shared-swift/Toolkit/Extensions/Collection.swift
+++ b/r2-shared-swift/Toolkit/Extensions/Collection.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+extension Collection {
+
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    func getOrNil(_ index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+
+}

--- a/r2-shared-swift/Toolkit/Weak.swift
+++ b/r2-shared-swift/Toolkit/Weak.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+/// Smart pointer holding a weak reference to a reference-based object.
+///
+/// Get the reference by calling `weakVar()`.
+/// Conveniently, the reference can be reset by setting the `ref` property.
+@dynamicCallable
+public final class Weak<T: AnyObject> {
+
+    // Weakly held reference.
+    public weak var ref: T?
+
+    public init(_ ref: T? = nil) {
+        self.ref = ref
+    }
+
+    public func dynamicallyCall(withArguments args: [Any]) -> T? {
+        ref
+    }
+}

--- a/r2-shared-swiftTests/Publication/Services/Locator/DefaultLocatorServiceTests.swift
+++ b/r2-shared-swiftTests/Publication/Services/Locator/DefaultLocatorServiceTests.swift
@@ -1,0 +1,206 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import XCTest
+@testable import R2Shared
+
+class DefaultLocatorServiceTests: XCTestCase {
+
+    // locate(Locator) checks that the href exists.
+    func testFromLocator() {
+        let service = makeService(readingOrder: [
+            Link(href: "chap1", type: "application/xml"),
+            Link(href: "chap2", type: "application/xml"),
+            Link(href: "chap3", type: "application/xml"),
+        ])
+        let locator = Locator(href: "chap2", type: "text/html", text: .init(highlight: "Highlight"))
+        XCTAssertEqual(service.locate(locator), locator)
+    }
+
+    func testFromLocatorEmptyReadingOrder() {
+        let service = makeService(readingOrder: [])
+        XCTAssertNil(service.locate(Locator(href: "href", type: "text/html")))
+    }
+
+    func testFromLocatorNotFound() {
+        let service = makeService(readingOrder: [
+            Link(href: "chap1", type: "application/xml"),
+            Link(href: "chap3", type: "application/xml"),
+        ])
+        let locator = Locator(href: "chap2", type: "text/html", text: .init(highlight: "Highlight"))
+        XCTAssertNil(service.locate(locator))
+    }
+
+    func testFromProgression() {
+        let service = makeService(positions: positionsFixture)
+
+        XCTAssertEqual(service.locate(progression: 0.0), Locator(
+            href: "chap1",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 0.0,
+                totalProgression: 0.0,
+                position: 1
+            )
+        ))
+
+        XCTAssertEqual(service.locate(progression: 0.25), Locator(
+            href: "chap3",
+            type: "text/html",
+            title: "Chapter 3",
+            locations: Locator.Locations(
+                progression: 0.0,
+                totalProgression: 2.0/8.0,
+                position: 3
+            )
+        ))
+
+        let chap5FirstTotalProg = 5.0/8.0
+        let chap4FirstTotalProg = 3.0/8.0
+
+        XCTAssertEqual(service.locate(progression: 0.4), Locator(
+            href: "chap4",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: (0.4 - chap4FirstTotalProg) / (chap5FirstTotalProg - chap4FirstTotalProg),
+                totalProgression: 0.4,
+                position: 4
+            )
+        ))
+
+        XCTAssertEqual(service.locate(progression: 0.55), Locator(
+            href: "chap4",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: (0.55 - chap4FirstTotalProg) / (chap5FirstTotalProg - chap4FirstTotalProg),
+                totalProgression: 0.55,
+                position: 5
+            )
+        ))
+
+        XCTAssertEqual(service.locate(progression: 0.9), Locator(
+            href: "chap5",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: (0.9 - chap5FirstTotalProg) / (1.0 - chap5FirstTotalProg),
+                totalProgression: 0.9,
+                position: 8
+            )
+        ))
+
+        XCTAssertEqual(service.locate(progression: 1.0), Locator(
+            href: "chap5",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 1.0,
+                totalProgression: 1.0,
+                position: 8
+            )
+        ))
+    }
+
+    func testFromIncorrectProgression() {
+        let service = makeService(positions: positionsFixture)
+        XCTAssertNil(service.locate(progression: -0.2))
+        XCTAssertNil(service.locate(progression: 1.2))
+    }
+
+    func testFromProgressionEmptyPositions() {
+        let service = makeService(positions: [])
+        XCTAssertNil(service.locate(progression: 0.5))
+    }
+
+    func makeService(readingOrder: [Link] = [], positions: [[Locator]] = []) -> DefaultLocatorService {
+        DefaultLocatorService(readingOrder: readingOrder, positionsByReadingOrder: { positions })
+    }
+
+}
+
+private let positionsFixture: [[Locator]] = [
+    [
+        Locator(
+            href: "chap1",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 0.0,
+                totalProgression: 0.0,
+                position: 1
+            )
+        )
+    ],
+    [
+        Locator(
+            href: "chap2",
+            type: "application/xml",
+            locations: Locator.Locations(
+                progression: 0.0,
+                totalProgression: 1.0/8.0,
+                position: 2
+            )
+        )
+    ],
+    [
+        Locator(
+            href: "chap3",
+            type: "text/html",
+            title: "Chapter 3",
+            locations: Locator.Locations(
+                progression: 0.0,
+                totalProgression: 2.0/8.0,
+                position: 3
+            )
+        )
+    ],
+    [
+        Locator(
+            href: "chap4",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 0.0,
+                totalProgression: 3.0/8.0,
+                position: 4
+            )
+        ),
+        Locator(
+            href: "chap4",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 0.5,
+                totalProgression: 4.0/8.0,
+                position: 5
+            )
+        )
+    ],
+    [
+        Locator(
+            href: "chap5",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 0.0,
+                totalProgression: 5.0/8.0,
+                position: 6
+            )
+        ),
+        Locator(
+            href: "chap5",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 1.0/3.0,
+                totalProgression: 6.0/8.0,
+                position: 7
+            )
+        ),
+        Locator(
+            href: "chap5",
+            type: "text/html",
+            locations: Locator.Locations(
+                progression: 2.0/3.0,
+                totalProgression: 7.0/8.0,
+                position: 8
+            )
+        )
+    ]
+]

--- a/r2-shared-swiftTests/Publication/Services/PublicationServicesBuilderTests.swift
+++ b/r2-shared-swiftTests/Publication/Services/PublicationServicesBuilderTests.swift
@@ -23,6 +23,7 @@ struct BarServiceA: BarService {}
 class PublicationServicesBuilderTests: XCTestCase {
     
     private let context = PublicationServiceContext(
+        publication: Weak<Publication>(),
         manifest: Manifest(metadata: Metadata(title: "")),
         fetcher: EmptyFetcher()
     )


### PR DESCRIPTION
* `PublicationServiceContext` now holds a weak reference to the parent `Publication`. This can be used to access other services from a given `PublicationService` implementation.
* The default `LocatorService` implementation can be used to get a `Locator` from a global progression in the publication.
    * `publication.locate(progression: 0.5)`