### PR TITLE
Add a new Resource API for asynchronous reads

### DIFF
--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		CA17638D223A984600959FEB /* Publication.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9E6BA6223A67D300ECF6E4 /* Publication.swift */; };
 		CA176392223AAC1A00959FEB /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA176391223AAC1A00959FEB /* UserSettings.swift */; };
 		CA1AB0C424E2D0EA00004BC0 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1AB0C324E2D0EA00004BC0 /* URL.swift */; };
+		CA1C110125EF86E1001EA019 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C10EF25EEAEBF001EA019 /* Cancellable.swift */; };
 		CA2006512225A1F300E6B3BD /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2006502225A1F300E6B3BD /* Observable.swift */; };
 		CA228D1124BC5CF800879E2E /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA228D1024BC5CF800879E2E /* Result.swift */; };
 		CA228D1924BCE27300879E2E /* WarningLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA228D1824BCE27300879E2E /* WarningLogger.swift */; };
@@ -257,6 +258,7 @@
 		CA176386223A898B00959FEB /* Properties+EPUB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Properties+EPUB.swift"; sourceTree = "<group>"; };
 		CA176391223AAC1A00959FEB /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		CA1AB0C324E2D0EA00004BC0 /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
+		CA1C10EF25EEAEBF001EA019 /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		CA2006502225A1F300E6B3BD /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		CA228D1024BC5CF800879E2E /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		CA228D1824BCE27300879E2E /* WarningLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningLogger.swift; sourceTree = "<group>"; };
@@ -477,6 +479,7 @@
 				3ED94B721E98E44B73A50CCB /* Media Type */,
 				CA0D3C0D2518E1F9005B47BC /* PDF */,
 				CA60CE1E2446DE7500149B22 /* XML */,
+				CA1C10EF25EEAEBF001EA019 /* Cancellable.swift */,
 				CA228D1E24BDDDAF00879E2E /* CancellableResult.swift */,
 				F3E7D4221F4ECB3D00DF166D /* Date+ISO8601.swift */,
 				CABEB3DB2215698600090B6C /* Deferred.swift */,
@@ -1295,6 +1298,7 @@
 				CACDE5D52483A7AC006FEB1B /* CoverService.swift in Sources */,
 				CABBB2E72237ADEB004EB039 /* Facet.swift in Sources */,
 				CA16A8822233FE3200E66255 /* Metadata.swift in Sources */,
+				CA1C110125EF86E1001EA019 /* Cancellable.swift in Sources */,
 				CA3386E12404FAD000FDCBBA /* Encryption.swift in Sources */,
 				CAF4EAE52237ABC700A17DA1 /* MediaOverlays.swift in Sources */,
 				CA3386EE24056ADB00FDCBBA /* Locator+HTML.swift in Sources */,

--- a/r2-shared-swift/Toolkit/Cancellable.swift
+++ b/r2-shared-swift/Toolkit/Cancellable.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+/// A protocol indicating that an activity or action supports cancellation.
+public protocol Cancellable {
+
+    /// Cancel the on-going activity.
+    func cancel()
+
+}
+
+/// A `Cancellable` object saving its cancelled state.
+public final class CancellableObject: Cancellable {
+    public private(set) var isCancelled = false
+
+    public func cancel() {
+        isCancelled = true
+    }
+}

--- a/r2-shared-swift/Toolkit/Extensions/String.swift
+++ b/r2-shared-swift/Toolkit/Extensions/String.swift
@@ -30,4 +30,12 @@ extension String {
         return String(dropFirst(prefix.count))
     }
 
+    /// Replaces the `prefix`, if present, by the given `replacement` prefix.
+    public func replacingPrefix(_ prefix: String, by replacement: String) -> String {
+        guard hasPrefix(prefix) else {
+            return self
+        }
+        return removingPrefix(prefix).addingPrefix(replacement)
+    }
+
 }

--- a/r2-shared-swift/Toolkit/Media Type/MediaType.swift
+++ b/r2-shared-swift/Toolkit/Media Type/MediaType.swift
@@ -79,6 +79,11 @@ public struct MediaType: Hashable, Loggable {
         MediaType.of(mediaType: string) ?? self
     }
 
+    /// Returns the UTI (Uniform Type Identifier) matching this media type, if any.
+    public var uti: String? {
+        UTI.findFrom(mediaTypes: [self], fileExtensions: Array(ofNotNil: fileExtension))?.string
+    }
+
     public init?(_ string: String, name: String? = nil, fileExtension: String? = nil) {
         guard !string.isEmpty else {
             return nil

--- a/r2-shared-swiftTests/Toolkit/Media Type/MediaTypeTests.swift
+++ b/r2-shared-swiftTests/Toolkit/Media Type/MediaTypeTests.swift
@@ -106,6 +106,11 @@ class MediaTypeTests: XCTestCase {
         XCTAssertEqual(MediaType("application/unknown;charset=utf-8")!.canonicalized, MediaType("application/unknown;charset=utf-8"))
     }
 
+    func testUTI() {
+        XCTAssertEqual(MediaType.mp3.uti, "public.mp3")
+        XCTAssertEqual(MediaType("application/unknown")!.uti, "dyn.agq80c6durvy0g2pyrf106p5zr3z06551r2")
+    }
+
     func testEquals() {
         XCTAssertEqual(MediaType("application/atom+xml")!, MediaType("application/atom+xml")!)
         XCTAssertEqual(MediaType("application/atom+xml;profile=opds-catalog")!, MediaType("application/atom+xml;profile=opds-catalog")!)


### PR DESCRIPTION
* Add a new `Resource` API for asynchronous reads. It will be useful when serving a streamed resource like a remote audiobook.
    ```swift
    /// Reads the bytes at the given range asynchronously.
    ///
    /// The `consume` callback will be called with each chunk of read data. Callers are responsible to accumulate the
    /// total data.
    /// The returned `Cancellable` object can be used to cancel the reading task if not needed anymore.
    ///
    /// Types implementing Resource MUST override either this function or `read(range:)`.
    func read(range: Range<UInt64>?, consume: @escaping (Data) -> Void, completion: @escaping (ResourceResult<Void>) -> Void) -> Cancellable
    ```
* Add `MediaType.uti` to transform a media type into a Uniform Type Identifier, which is used in various Apple API.