### PR TITLE
Support Archive resource ownership at the entry level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-* CocoaPods is not supported anymore.
+* CocoaPods is not supported anymore (i.e. [PR #129](https://github.com/readium/r2-shared-swift/pull/129))
+* The `Archive` API now supports resource ownership at the entry level.
+    * The default ZIP implementation takes advantage of this by opening a new ZIP stream for each resource to be served. This improves performances and memory safety.
 
 ### Fixed
 

--- a/r2-shared-swift/Fetcher/HTTPFetcher.swift
+++ b/r2-shared-swift/Fetcher/HTTPFetcher.swift
@@ -83,7 +83,7 @@ public final class HTTPFetcher: Fetcher {
             headResponse.flatMap {
                 let length = $0.expectedContentLength
                 if length < 0 {
-                    return .failure(.unavailable)
+                    return .failure(.unavailable(nil))
                 } else {
                     return .success(UInt64(length))
                 }
@@ -97,7 +97,7 @@ public final class HTTPFetcher: Fetcher {
         
         func read(range: Range<UInt64>?) -> ResourceResult<Data> {
             // FIXME:
-            return .failure(.unavailable)
+            return .failure(.unavailable(nil))
 //            if let range = range {
 //                return headResponse.flatMap { response in
 //                    var request = URLRequest(url: url)
@@ -150,7 +150,7 @@ private extension URLSession {
                     case 404:
                         return .notFound
                     case 503:
-                        return .unavailable
+                        return .unavailable(nil)
                     default:
                         return .other(HTTPFetcher.Error.serverFailure)
                     }

--- a/r2-shared-swift/Fetcher/Resource/Resource.swift
+++ b/r2-shared-swift/Fetcher/Resource/Resource.swift
@@ -95,7 +95,7 @@ public enum ResourceError: LocalizedError {
     ///
     /// Used when the source can't be reached, e.g. no Internet connection, or an issue with the
     /// file system. Usually this is a temporary error.
-    case unavailable
+    case unavailable(Error?)
     
     /// For any other error, such as HTTP 500.
     case other(Error)

--- a/r2-shared-swift/Publication/Asset/FileAsset.swift
+++ b/r2-shared-swift/Publication/Asset/FileAsset.swift
@@ -53,7 +53,7 @@ public final class FileAsset: PublicationAsset, Loggable {
     
             do {
                 // Attempts to open the file as a ZIP or exploded directory.
-                let archive = try dependencies.archiveFactory.open(url: self.url, password: credentials)
+                let archive = try dependencies.archiveFactory.open(url: self.url, password: credentials).get()
                 completion(.success(ArchiveFetcher(archive: archive)))
         
             } catch ArchiveError.invalidPassword {

--- a/r2-shared-swift/Toolkit/Archive/Minizip.swift
+++ b/r2-shared-swift/Toolkit/Archive/Minizip.swift
@@ -1,145 +1,211 @@
 //
-//  Minizip.swift
-//  r2-shared-swift
-//
-//  Created by Mickaël Menu on 15/04/2020.
-//
 //  Copyright 2020 Readium Foundation. All rights reserved.
-//  Use of this source code is governed by a BSD-style license which is detailed
-//  in the LICENSE file present in the project repository where this source code is maintained.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
 //
 
 import Foundation
 import Minizip
 
+enum MinizipArchiveError: Error {
+    case notAFileURL(URL)
+    case fileNotReachable(URL)
+    case notAValidZIP(URL)
+    case entryAlreadyClosed(ArchivePath)
+}
+
 /// A ZIP `Archive` using the Minizip library.
 final class MinizipArchive: Archive, Loggable {
 
-    private let archive: unzFile
-
-    init(url: URL, password: String?) throws {
-        assert(url.isFileURL, "Only file URLs are supported by MinizipArchive")
-        
-        guard (try? url.checkResourceIsReachable()) ?? false,
-            let archive = unzOpen64(url.path) else
-        {
-            throw ArchiveError.openFailed
+    static func make(url: URL) -> ArchiveResult<MinizipArchive> {
+        guard url.isFileURL else {
+            return .failure(.openFailed(archive: url, cause: MinizipArchiveError.notAFileURL(url)))
         }
+        guard (try? url.checkResourceIsReachable()) ?? false else {
+            return .failure(.openFailed(archive: url, cause: MinizipArchiveError.fileNotReachable(url)))
+        }
+        guard let file = MinizipFile(url: url) else {
+            return .failure(.openFailed(archive: url, cause: MinizipArchiveError.notAValidZIP(url)))
+        }
+        defer { try? file.close() }
+
+        do {
+            var entries: [ArchiveEntry] = []
+
+            try file.goToFirstEntry()
+            repeat {
+                switch try file.entryMetadataAtCurrentOffset() {
+                case let .file(path, length: length, compressedLength: compressedLength):
+                    entries.append(ArchiveEntry(path: path.addingPrefix("/"), length: length, compressedLength: compressedLength))
+                case .directory:
+                    // Directories are ignored
+                    break
+                }
+            } while try file.goToNextEntry()
+
+            return .success(try Self(url: url, entries: entries))
+
+        } catch {
+            return .failure(.openFailed(archive: url, cause: error))
+        }
+    }
+
+    let entries: [ArchiveEntry]
+
+    private let url: URL
+
+    private init(url: URL, entries: [ArchiveEntry]) throws {
+        self.url = url
+        self.entries = entries
+    }
+
+    func readEntry(at path: ArchivePath) -> ArchiveEntryReader? {
+        guard let entry = self.entry(at: path) else {
+            return nil
+        }
+        return MinizipEntryReader(archive: url, entry: entry)
+    }
+
+    func close() {}
+}
+
+private final class MinizipEntryReader: ArchiveEntryReader, Loggable {
+
+    private let archive: URL
+    private let entry: ArchiveEntry
+    private var isClosed = false
+
+    init(archive: URL, entry: ArchiveEntry) {
         self.archive = archive
-
-        initEntries()
-    }
-    
-    deinit {
-        close()
+        self.entry = entry
     }
 
-    private(set) var entries: [ArchiveEntry] = []
-    private var entriesByPath: [String: ArchiveEntry] = [:]
-
-    private func initEntries() {
-        assert(entries.isEmpty, "already initialized entries")
-        guard goToFirstEntry() else {
-            return
-        }
-
-        repeat {
-            if let entry = makeEntryAtCurrentOffset() {
-                entries.append(entry)
-                entriesByPath[entry.path] = entry
-            }
-        } while goToNextEntry()
-    }
-
-    func entry(at path: String) throws -> ArchiveEntry {
-        guard let entry = entriesByPath[path] else {
-            throw ArchiveError.entryNotFound
-        }
-        return entry
-    }
-    
-    func read(at path: String) -> Data? {
-        return transaction {
-            guard
-                let length = entriesByPath[path]?.length,
-                openEntry(at: path)
-            else {
-                return nil
-            }
-            defer {
-                closeEntry()
-            }
-            return readFromCurrentOffset(length: length)
-        }
-    }
-    
-    func read(at path: String, range: Range<UInt64>) -> Data? {
-        return transaction {
-            guard openEntry(at: path, offset: range.lowerBound) else {
-                return nil
-            }
-
-            let length = (range.upperBound - range.lowerBound)
-            return readFromCurrentOffset(length: length)
-        }
-    }
-    
-    /// Makes the access to the Minizip archive thread-safe.
-    @discardableResult
-    private func transaction<T>(_ block: () throws -> T) rethrows -> T {
-        objc_sync_enter(self)
-        defer { objc_sync_exit(self) }
-        return try block()
-    }
-    
     func close() {
         transaction {
-            closeEntry()
-            unzClose(archive)
+            do {
+                try _file?.close()
+                isClosed = true
+            } catch {
+                log(.error, error)
+            }
         }
     }
 
+    func read(range: Range<UInt64>?) -> ArchiveResult<Data> {
+        transaction {
+            let range = range ?? 0..<entry.length
 
-    // MARK: Minizip C++ Bridge
+            do {
+                let file = try self.file()
+                try file.openEntry(at: entry.path, offset: range.lowerBound)
+                return .success(try file.readFromCurrentOffset(length: UInt64(range.count)))
 
+            } catch {
+                return .failure(.readFailed(entry: entry.path, archive: archive, cause: error))
+            }
+        }
+    }
+
+    private var _file: MinizipFile?
+    private func file() throws -> MinizipFile {
+        if let file = _file {
+            return file
+        } else if let file = MinizipFile(url: archive) {
+            _file = file
+            return file
+        } else {
+            throw MinizipArchiveError.notAValidZIP(archive)
+        }
+    }
+
+    /// Makes the access to the Minizip file thread-safe.
+    @discardableResult
+    private func transaction<T>(_ block: () throws -> T) rethrows -> T {
+        try queue.sync {
+            guard !isClosed else {
+                throw MinizipArchiveError.entryAlreadyClosed(entry.path)
+            }
+
+            return try block()
+        }
+    }
+    private let queue = DispatchQueue(label: "org.readium.r2-shared-swift.MinizipFile")
+
+}
+
+/// Holds an opened Minizip file and provide a bridge to its C++ API.
+private final class MinizipFile {
+
+    enum MinizipError: Error {
+        case status(Int32)
+        case noEntryOpened
+        case readFailed
+    }
+
+    // Holds an entry's metadata.
+    enum Entry {
+        case file(ArchivePath, length: UInt64, compressedLength: UInt64?)
+        case directory(ArchivePath)
+    }
+
+    private let file: unzFile
+    private var isClosed = false
     /// Information about the currently opened entry.
-    private var openedEntry: (path: String, offset: UInt64)? = nil
-
+    private(set) var openedEntry: (path: ArchivePath, offset: UInt64)? = nil
     /// Length of the buffer used when reading an entry's data.
-    private var bufferLength: Int { 1024 * 64 }
+    private var bufferLength: Int { 1024 * 32 }
+
+    init?(url: URL) {
+        guard let file = unzOpen64(url.path) else {
+            return nil
+        }
+        self.file = file
+    }
+
+    deinit {
+        try? close()
+    }
+
+    func close() throws {
+        guard !isClosed else {
+            return
+        }
+        try closeEntry()
+        try execute { unzClose(file) }
+        isClosed = true
+    }
 
     /// Moves offset to the first entry in the archive.
-    private func goToFirstEntry() -> Bool {
-        closeEntry()
-        return execute { unzGoToFirstFile(archive) }
+    func goToFirstEntry() throws {
+        try closeEntry()
+        try execute { unzGoToFirstFile(file) }
     }
-    
+
     /// Moves offset to the next entry in the archive.
     ///
-    /// - Returns: `false` in case of EOF or error.
-    private func goToNextEntry() -> Bool {
-        closeEntry()
+    /// - Returns: `false` when reaching the end of the archive.
+    func goToNextEntry() throws -> Bool {
+        try closeEntry()
 
-        let status = unzGoToNextFile(archive)
+        let status = unzGoToNextFile(file)
         switch status {
         case UNZ_END_OF_LIST_OF_FILE:
             return false
         case UNZ_OK:
             return true
         default:
-            log(.error, "Minizip error: #\(status)")
-            return false
+            throw MinizipError.status(status)
         }
     }
-    
+
     /// Moves the offset to the entry at `path`.
-    private func goToEntry(at path: String) -> Bool {
-        closeEntry()
-        return unzLocateFile(archive, path, nil) == UNZ_OK
+    func goToEntry(at path: ArchivePath) throws {
+        try closeEntry()
+        try execute { unzLocateFile(file, path.removingPrefix("/"), nil) }
     }
-    
-    /// Creates an `ArchiveEntry` from the entry at the current offset in the archive.
-    private func makeEntryAtCurrentOffset() -> ArchiveEntry? {
+
+    /// Reads the metadata of the entry at the current offset in the archive.
+    func entryMetadataAtCurrentOffset() throws -> Entry {
         let filenameMaxSize = 1024
         var fileInfo = unz_file_info64()
         let filename = UnsafeMutablePointer<CChar>.allocate(capacity: filenameMaxSize)
@@ -147,64 +213,50 @@ final class MinizipArchive: Archive, Loggable {
             free(filename)
         }
         memset(&fileInfo, 0, MemoryLayout<unz_file_info64>.size)
-        guard execute({ unzGetCurrentFileInfo64(archive, &fileInfo, filename, UInt(filenameMaxSize), nil, 0, nil, 0) }) else {
-            return nil
-        }
+        try execute { unzGetCurrentFileInfo64(file, &fileInfo, filename, UInt(filenameMaxSize), nil, 0, nil, 0) }
         let path = String(cString: filename)
-        
-        // We ignore directories.
-        guard !path.hasSuffix("/") else {
-            return nil
+
+        if path.hasSuffix("/") {
+            return .directory(path)
+        } else {
+            let isCompressed = (fileInfo.compression_method != 0)
+            return .file(path,
+                length: UInt64(fileInfo.uncompressed_size),
+                compressedLength: isCompressed ? UInt64(fileInfo.compressed_size) : nil
+            )
         }
-        
-        let isCompressed = (fileInfo.compression_method != 0)
-        
-        return ArchiveEntry(
-            path: path,
-            length: UInt64(fileInfo.uncompressed_size),
-            isCompressed: isCompressed,
-            compressedLength: isCompressed ? UInt64(fileInfo.compressed_size) : nil
-        )
     }
-    
+
     /// Opens the entry at the given `path` and file `offset`, to read its content.
-    private func openEntry(at path: String, offset: UInt64 = 0) -> Bool {
+    func openEntry(at path: ArchivePath, offset: UInt64 = 0) throws {
         if let entry = openedEntry, entry.path == path, entry.offset <= offset {
             if entry.offset < offset {
-                return seek(by: offset - entry.offset)
-            } else {
-                return true
+                try seek(by: offset - entry.offset)
             }
 
         } else {
-            guard
-                goToEntry(at: path),
-                execute({ unzOpenCurrentFile(archive) })
-            else {
-                return false
-            }
+            try goToEntry(at: path)
+            try execute { unzOpenCurrentFile(file) }
             openedEntry = (path: path, offset: 0)
-            return seek(by: offset)
+            try seek(by: offset)
         }
     }
 
     /// Closes the current entry if it is opened.
-    private func closeEntry() {
+    func closeEntry() throws {
         guard openedEntry != nil else {
             return
         }
         openedEntry = nil
-        _ = execute { unzCloseCurrentFile(archive) }
+        try execute { unzCloseCurrentFile(file) }
     }
-    
+
     /// Advances the current position in the archive by the given `offset`.
-    ///
-    /// - Returns: Whether the seeking operation was successful.
-    private func seek(by offset: UInt64) -> Bool {
+    func seek(by offset: UInt64) throws {
         // Deflate is stream-based, and can't be used for random access. Therefore, if the file
         // is compressed we need to read and discard the content from the start until we reach
         // the desired offset.
-        return readFromCurrentOffset(length: offset) { _, _ in }
+        try readFromCurrentOffset(length: offset) { _, _ in }
 
         // For non-compressed entries, we can seek directly in the content.
         // FIXME: https://github.com/readium/r2-shared-swift/issues/98
@@ -212,31 +264,28 @@ final class MinizipArchive: Archive, Loggable {
     }
 
     /// Reads the given `length` of data at the current offset in the archive.
-    private func readFromCurrentOffset(length: UInt64) -> Data? {
+    func readFromCurrentOffset(length: UInt64) throws -> Data {
         guard length > 0 else {
-            return nil
+            return Data()
         }
 
         var data = Data(capacity: Int(length))
-        let success = readFromCurrentOffset(length: length) { (bytes, length) in
+        try readFromCurrentOffset(length: length) { (bytes, length) in
             data.append(bytes, count: Int(length))
         }
-        return success ? data : nil
+        return data
     }
-    
-    private typealias Consumer = (_ bytes: UnsafePointer<UInt8>, _ length: UInt64) -> Void
-    
+
+    typealias Consumer = (_ bytes: UnsafePointer<UInt8>, _ length: UInt64) -> Void
+
     /// Consumes the given `length` of data at the current offset in the archive.
-    private func readFromCurrentOffset(length: UInt64, consumer: Consumer) -> Bool {
+    func readFromCurrentOffset(length: UInt64, consumer: Consumer) throws {
         guard var entry = openedEntry else {
-            log(.error, "Trying to read while no entry was opened")
-            return false
+            throw MinizipError.noEntryOpened
         }
         guard length > 0 else {
-            return true
+            return
         }
-
-        var buffer = Array<CUnsignedChar>(repeating: 0, count: bufferLength)
 
         var totalBytesRead: UInt64 = 0
         defer {
@@ -246,7 +295,8 @@ final class MinizipArchive: Archive, Loggable {
 
         while totalBytesRead < length {
             let bytesToRead = min(UInt64(bufferLength), length - totalBytesRead)
-            let bytesRead = UInt64(unzReadCurrentFile(archive, &buffer, UInt32(bytesToRead)))
+            var buffer = Array<CUnsignedChar>(repeating: 0, count: Int(bytesToRead))
+            let bytesRead = UInt64(unzReadCurrentFile(file, &buffer, UInt32(bytesToRead)))
             if bytesRead == 0 {
                 break
             }
@@ -254,23 +304,18 @@ final class MinizipArchive: Archive, Loggable {
                 totalBytesRead += bytesRead
                 consumer(buffer, bytesRead)
             } else {
-                log(.error, "Minizip error: Can't read current entry")
-                return false
+                throw MinizipError.readFailed
             }
         }
-        return true
     }
 
     /// Executes a Minizip statement and checks its status.
-    ///
-    /// - Returns: Whether the statement was successful.
-    private func execute(_ block: () -> Int32) -> Bool {
+    private func execute(_ block: () -> Int32) throws {
         let status = block()
         guard status == UNZ_OK else {
-            log(.error, "Minizip error: #\(status)")
-            return false
+            throw MinizipError.status(status)
         }
-        return true
     }
 
 }
+

--- a/r2-shared-swift/Toolkit/Extensions/Result.swift
+++ b/r2-shared-swift/Toolkit/Extensions/Result.swift
@@ -17,4 +17,11 @@ extension Result {
         return try? get()
     }
 
+    func `catch`(_ recover: (Failure) -> Self) -> Self {
+        if case .failure(let error) = self {
+            return recover(error)
+        }
+        return self
+    }
+
 }

--- a/r2-shared-swift/Toolkit/Media Type/MediaTypeSniffer.swift
+++ b/r2-shared-swift/Toolkit/Media Type/MediaTypeSniffer.swift
@@ -214,7 +214,7 @@ public extension MediaType {
         func readRWPM() -> (isManifest: Bool, Manifest)? {
             if let rwpm = context.contentAsRWPM {
                 return (isManifest: true, rwpm)
-            } else if let manifestData = context.readArchiveEntry(at: "manifest.json"),
+            } else if let manifestData = context.readArchiveEntry(at: "/manifest.json"),
                 let manifestJSON = try? JSONSerialization.jsonObject(with: manifestData),
                 let rwpm = try? Manifest(json: manifestJSON) {
                 return (isManifest: false, rwpm)
@@ -224,7 +224,7 @@ public extension MediaType {
         }
 
         if let (isManifest, rwpm) = readRWPM() {
-            let isLCPProtected = context.containsArchiveEntry(at: "license.lcpl")
+            let isLCPProtected = context.containsArchiveEntry(at: "/license.lcpl")
 
             if rwpm.metadata.type == "http://schema.org/Audiobook" || rwpm.readingOrder.allAreAudio {
                 return isManifest ? .readiumAudiobookManifest :
@@ -261,7 +261,7 @@ public extension MediaType {
         if context.hasFileExtension("epub") || context.hasMediaType("application/epub+zip") {
             return .epub
         }
-        if let mimetypeData = context.readArchiveEntry(at: "mimetype"),
+        if let mimetypeData = context.readArchiveEntry(at: "/mimetype"),
             let mimetype = String(data: mimetypeData, encoding: .ascii)?.trimmingCharacters(in: .whitespacesAndNewlines),
             mimetype == "application/epub+zip"
         {
@@ -278,10 +278,10 @@ public extension MediaType {
         if context.hasFileExtension("lpf") || context.hasMediaType("application/lpf+zip") {
             return .lpf
         }
-        if context.containsArchiveEntry(at: "index.html") {
+        if context.containsArchiveEntry(at: "/index.html") {
             return .lpf
         }
-        if let data = context.readArchiveEntry(at: "publication.json"),
+        if let data = context.readArchiveEntry(at: "/publication.json"),
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let contexts = json["@context"] as? [Any],
             contexts.contains(where: {($0 as? String) == "https://www.w3.org/ns/pub-context"})

--- a/r2-shared-swift/Toolkit/Media Type/MediaTypeSnifferContext.swift
+++ b/r2-shared-swift/Toolkit/Media Type/MediaTypeSnifferContext.swift
@@ -78,7 +78,7 @@ public final class MediaTypeSnifferContext {
     /// Content as an archive.
     /// Warning: ZIP is only supported for a local file, for now.
     lazy var contentAsArchive: Archive? = (content as? FileMediaTypeSnifferContent)
-        .flatMap { try? archiveFactory.open(url: $0.file, password: nil) }
+        .flatMap { archiveFactory.open(url: $0.file, password: nil).getOrNil() }
 
     /// Content parsed from JSON.
     public lazy var contentAsJSON: Any? = contentAsString
@@ -123,12 +123,12 @@ public final class MediaTypeSnifferContext {
     
     /// Returns whether an Archive entry exists in this file.
     func containsArchiveEntry(at path: String) -> Bool {
-        return (try? contentAsArchive?.entry(at: path)) != nil
+        return contentAsArchive?.entry(at: path) != nil
     }
     
     /// Returns the Archive entry data at the given `path` in this file.
     func readArchiveEntry(at path: String) -> Data? {
-        return contentAsArchive?.read(at: path)
+        return contentAsArchive?.readEntry(at: path)?.read().getOrNil()
     }
     
     /// Returns whether all the Archive entry paths satisfy the given `predicate`.

--- a/r2-shared-swiftTests/Fetcher/ArchiveFetcherTests.swift
+++ b/r2-shared-swiftTests/Fetcher/ArchiveFetcherTests.swift
@@ -19,7 +19,7 @@ class ArchiveFetcherTests: XCTestCase {
 
     override func setUpWithError() throws {
         let url = fixtures.url(for: "epub.epub")
-        fetcher = try ArchiveFetcher(archive: DefaultArchiveFactory().open(url: url, password: nil))
+        fetcher = try ArchiveFetcher(archive: DefaultArchiveFactory().open(url: url, password: nil).get())
     }
     
     func testLinks() {

--- a/r2-shared-swiftTests/Toolkit/Archive/Archive+ZIPTests.swift
+++ b/r2-shared-swiftTests/Toolkit/Archive/Archive+ZIPTests.swift
@@ -14,129 +14,138 @@ import XCTest
 
 fileprivate let fixtures = Fixtures(path: "Archive")
 
-struct ZIPTester<A: Archive> {
+struct ZIPTester {
+    let make: (URL) throws -> Archive
 
     func testOpenSuccess() {
-        XCTAssertNoThrow(try A(url: fixtures.url(for: "test.zip")))
+        XCTAssertNoThrow(try make(fixtures.url(for: "test.zip")))
     }
 
     func testOpenNotFound() {
-        XCTAssertThrowsError(try A(url: fixtures.url(for: "unknown.zip"))) { error in
-            XCTAssertEqual(error as? ArchiveError, ArchiveError.openFailed)
-        }
+        XCTAssertThrowsError(try make(fixtures.url(for: "unknown.zip")))
     }
     
     func testOpenNotAZIP() {
-        XCTAssertThrowsError(try A(url: fixtures.url(for: "not-a.zip"))) { error in
-            XCTAssertEqual(error as? ArchiveError, ArchiveError.openFailed)
-        }
+        XCTAssertThrowsError(try make(fixtures.url(for: "not-a.zip")))
     }
     
     func testGetNonExistingEntry() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
-        XCTAssertThrowsError(try archive.entry(at: "unknown")) { error in
-            XCTAssertEqual(error as? ArchiveError, ArchiveError.entryNotFound)
-        }
+        let archive = try make(fixtures.url(for: "test.zip"))
+        XCTAssertNil(archive.entry(at: "/unknown"))
     }
 
     func testGetFileEntry() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
+        let archive = try make(fixtures.url(for: "test.zip"))
         XCTAssertEqual(
-            try archive.entry(at: "A folder/wasteland-cover.jpg"),
+            archive.entry(at: "/A folder/wasteland-cover.jpg"),
             ArchiveEntry(
-                path: "A folder/wasteland-cover.jpg",
+                path: "/A folder/wasteland-cover.jpg",
                 length: 103477,
-                isCompressed: true,
                 compressedLength: 82374
             )
         )
     }
 
     func testGetUncompressedFileEntry() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
+        let archive = try make(fixtures.url(for: "test.zip"))
         XCTAssertEqual(
-            try archive.entry(at: "uncompressed.jpg"),
+            archive.entry(at: "/uncompressed.jpg"),
             ArchiveEntry(
-                path: "uncompressed.jpg",
+                path: "/uncompressed.jpg",
                 length: 279551,
-                isCompressed: false,
                 compressedLength: nil
             )
         )
     }
 
     func testGetDirectoryEntry() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
-        XCTAssertThrowsError(try archive.entry(at: "A folder")) { error in
-            XCTAssertEqual(error as? ArchiveError, ArchiveError.entryNotFound)
-        }
-        XCTAssertThrowsError(try archive.entry(at: "A folder/")) { error in
-            XCTAssertEqual(error as? ArchiveError, ArchiveError.entryNotFound)
-        }
+        let archive = try make(fixtures.url(for: "test.zip"))
+        XCTAssertNil(archive.entry(at: "/A folder"))
+        XCTAssertNil(archive.entry(at: "/A folder/"))
     }
     
     func testGetEntries() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
+        let archive = try make(fixtures.url(for: "test.zip"))
         XCTAssertEqual(archive.entries, [
-            ArchiveEntry(path: ".hidden", length: 0, isCompressed: false, compressedLength: nil),
-            ArchiveEntry(path: "A folder/Sub.folder%/file.txt", length: 20, isCompressed: false, compressedLength: nil),
-            ArchiveEntry(path: "A folder/wasteland-cover.jpg", length: 103477, isCompressed: true, compressedLength: 82374),
-            ArchiveEntry(path: "root.txt", length: 0, isCompressed: false, compressedLength: nil),
-            ArchiveEntry(path: "uncompressed.jpg", length: 279551, isCompressed: false, compressedLength: nil),
-            ArchiveEntry(path: "uncompressed.txt", length: 30, isCompressed: false, compressedLength: nil),
-            ArchiveEntry(path: "A folder/Sub.folder%/file-compressed.txt", length: 29609, isCompressed: true, compressedLength: 8659),
+            ArchiveEntry(path: "/.hidden", length: 0, compressedLength: nil),
+            ArchiveEntry(path: "/A folder/Sub.folder%/file.txt", length: 20, compressedLength: nil),
+            ArchiveEntry(path: "/A folder/wasteland-cover.jpg", length: 103477, compressedLength: 82374),
+            ArchiveEntry(path: "/root.txt", length: 0, compressedLength: nil),
+            ArchiveEntry(path: "/uncompressed.jpg", length: 279551, compressedLength: nil),
+            ArchiveEntry(path: "/uncompressed.txt", length: 30, compressedLength: nil),
+            ArchiveEntry(path: "/A folder/Sub.folder%/file-compressed.txt", length: 29609, compressedLength: 8659),
         ])
     }
 
     func testReadCompressedEntry() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
-        let entry = try archive.entry(at: "A folder/Sub.folder%/file-compressed.txt")
-        let data = archive.read(at: entry.path)
-        XCTAssertNotNil(data)
-        let string = String(data: data!, encoding: .utf8)!
+        let archive = try make(fixtures.url(for: "test.zip"))
+        let entry = try XCTUnwrap(archive.readEntry(at: "/A folder/Sub.folder%/file-compressed.txt"))
+        let data = try entry.read().get()
+        let string = String(data: data, encoding: .utf8)!
         XCTAssertEqual(string.count, 29609)
         XCTAssertTrue(string.hasPrefix("I'm inside\nthe ZIP."))
     }
     
     func testReadUncompressedEntry() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
-        let entry = try archive.entry(at: "A folder/Sub.folder%/file.txt")
-        let data = archive.read(at: entry.path)
+        let archive = try make(fixtures.url(for: "test.zip"))
+        let entry = try XCTUnwrap(archive.readEntry(at: "/A folder/Sub.folder%/file.txt"))
+        let data = try entry.read().get()
         XCTAssertNotNil(data)
         XCTAssertEqual(
-            String(data: data!, encoding: .utf8),
+            String(data: data, encoding: .utf8),
             "I'm inside\nthe ZIP.\n"
         )
     }
     
     func testReadUncompressedRange() throws {
         // FIXME: It looks like unzseek64 starts from the beginning of the file header, instead of the content. Reading a first byte solves this but then Minizip crashes randomly... Note that this only fails in the test case. I didn't see actual issues in LCPDF or videos embedded in EPUBs.
-        let archive = try A(url: fixtures.url(for: "test.zip"))
-        let entry = try archive.entry(at: "A folder/Sub.folder%/file.txt")
-        let data = archive.read(at: entry.path, range: 14..<20)
-        XCTAssertNotNil(data)
+        let archive = try make(fixtures.url(for: "test.zip"))
+        let entry = try XCTUnwrap(archive.readEntry(at: "/A folder/Sub.folder%/file.txt"))
+        let data = try entry.read(range: 14..<20).get()
         XCTAssertEqual(
-            String(data: data!, encoding: .utf8),
+            String(data: data, encoding: .utf8),
             " ZIP.\n"
         )
     }
     
     func testReadCompressedRange() throws {
-        let archive = try A(url: fixtures.url(for: "test.zip"))
-        let entry = try archive.entry(at: "A folder/Sub.folder%/file-compressed.txt")
-        let data = archive.read(at: entry.path, range: 14..<20)
-        XCTAssertNotNil(data)
+        let archive = try make(fixtures.url(for: "test.zip"))
+        let entry = try XCTUnwrap(archive.readEntry(at: "/A folder/Sub.folder%/file-compressed.txt"))
+        let data = try entry.read(range: 14..<20).get()
         XCTAssertEqual(
-            String(data: data!, encoding: .utf8),
+            String(data: data, encoding: .utf8),
             " ZIP.\n"
         )
     }
 
 }
 
+class MinizipTests: XCTestCase {
+    
+    lazy var tester = ZIPTester {
+        url in try MinizipArchive.make(url: url).get()
+    }
+
+    func testOpenSuccess() { tester.testOpenSuccess() }
+    func testOpenNotFound() { tester.testOpenNotFound() }
+    func testOpenNotAZIP() { tester.testOpenNotAZIP() }
+    func testGetNonExistingEntry() throws { try tester.testGetNonExistingEntry() }
+    func testGetFileEntry() throws { try tester.testGetFileEntry() }
+    func testGetUncompressedFileEntry() throws { try tester.testGetUncompressedFileEntry() }
+    func testGetDirectoryEntry() throws { try tester.testGetDirectoryEntry() }
+    func testGetEntries() throws { try tester.testGetEntries() }
+    func testReadCompressedEntry() throws { try tester.testReadCompressedEntry() }
+    func testReadUncompressedEntry() throws { try tester.testReadUncompressedEntry() }
+    func testReadCompressedRange() throws { try tester.testReadCompressedRange() }
+    func testReadUncompressedRange() throws { try tester.testReadUncompressedRange() }
+    
+}
+
 //class ZIPFoundationTests: XCTestCase {
 //
-//    lazy var tester = ZIPTester<ZIPFoundationArchive>()
+//    lazy var tester = ZIPTester {
+//        url in try ZIPFoundation.make(url: url).get()
+//    }
 //
 //    func testOpenSuccess() { tester.testOpenSuccess() }
 //    func testOpenNotFound() { tester.testOpenNotFound() }
@@ -153,40 +162,24 @@ struct ZIPTester<A: Archive> {
 //
 //}
 
-class MinizipTests: XCTestCase {
-    
-    lazy var tester = ZIPTester<MinizipArchive>()
-    
-    func testOpenSuccess() { tester.testOpenSuccess() }
-    func testOpenNotFound() { tester.testOpenNotFound() }
-    func testOpenNotAZIP() { tester.testOpenNotAZIP() }
-    func testGetNonExistingEntry() throws { try tester.testGetNonExistingEntry() }
-    func testGetFileEntry() throws { try tester.testGetFileEntry() }
-    func testGetUncompressedFileEntry() throws { try tester.testGetUncompressedFileEntry() }
-    func testGetDirectoryEntry() throws { try tester.testGetDirectoryEntry() }
-    func testGetEntries() throws { try tester.testGetEntries() }
-    func testReadCompressedEntry() throws { try tester.testReadCompressedEntry() }
-    func testReadUncompressedEntry() throws { try tester.testReadUncompressedEntry() }
-    func testReadCompressedRange() throws { try tester.testReadCompressedRange() }
-    func testReadUncompressedRange() throws { try tester.testReadUncompressedRange() }
-    
-}
-
 class ZIPBenchmarkingTests: XCTestCase {
     
-    func testCompareRange() {
+    func testCompareRange() throws {
         let archives: [Archive] = [
-            try! MinizipArchive(url: fixtures.url(for: "test.zip")),
+            try! MinizipArchive.make(url: fixtures.url(for: "test.zip")).get(),
 //            try! ZIPFoundationArchive(url: fixtures.url(for: "test.zip"))
         ]
-        let path = "A folder/wasteland-cover.jpg"
+        let path = "/A folder/wasteland-cover.jpg"
         let length: UInt64 = 103477
+
+        let entries = try archives
+            .map { try XCTUnwrap($0.readEntry(at: path)) }
 
         measure {
             let lower = UInt64.random(in: 0..<length - 100)
             let upper = UInt64.random(in: lower..<length)
             let range = lower..<upper
-            let datas = archives.map { $0.read(at: path, range: range) }
+            let datas = entries.map { $0.read(range: range).getOrNil() }
             let data = datas[0]
             XCTAssertTrue(datas.allSatisfy { $0 == data })
         }


### PR DESCRIPTION
* The `Archive` API now supports resource ownership at the entry level.
    * The default ZIP implementation takes advantage of this by opening a new ZIP stream for each resource to be served. This improves performances and memory safety.