### PR TITLE
Use Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ## Build generated
 build/
 DerivedData/
+.build/
 
 ## Various settings
 *.pbxuser

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Fuzi",
+        "repositoryURL": "https://github.com/cezheng/Fuzi.git",
+        "state": {
+          "branch": null,
+          "revision": "f08c8323da21e985f3772610753bcfc652c2103f",
+          "version": "3.1.3"
+        }
+      },
+      {
+        "package": "Zip",
+        "repositoryURL": "https://github.com/marmelroy/Zip.git",
+        "state": {
+          "branch": null,
+          "revision": "bd19d974e8a38cc8d3a88c90c8a107386c3b8ccf",
+          "version": "2.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "r2-shared-swift",
+    platforms: [.iOS(.v10)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "r2-shared-swift",
+            targets: ["r2-shared-swift"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/marmelroy/Zip.git", .exact("2.1.1")),
+        .package(url: "https://github.com/cezheng/Fuzi.git", .exact("3.1.3")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "r2-shared-swift",
+            dependencies: ["Zip", "Fuzi"]),
+        .testTarget(
+            name: "r2-shared-swiftTests",
+            dependencies: ["r2-shared-swift"]),
+    ]
+)


### PR DESCRIPTION
Since this is used across the other modules, it makes sense to start with this one.

The following was done:

1. cezheng/Fuzi and dexman/Minizip removed from the Cartfile
2. cezheng/Fuzi added as a Swift package to the project (keeping the same version of 3.1.3)
3. https://github.com/marmelroy/Zip added as a Swift package to replace Minizip
4. Redid the travis configuration a bit.  I looked around a few other iOS repositories and they all rely on passing arguments in `xcodebuild`

I did not create a Package.swift file to make this SPM ready (yet). I want to get feedback on the rest of this first, then I'll add one and submit for review.