### PR TITLE
Fix Swift Package Manager support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,7 +12,7 @@
       },
       {
         "package": "SwiftSoup",
-        "repositoryURL": "https://github.com/scinfu/SwiftSoup",
+        "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {
           "branch": null,
           "revision": "774dc9c7213085db8aa59595e27c1cd22e428904",

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/cezheng/Fuzi.git", from: "3.1.3"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.1"),
-        .package(url: "https://github.com/scinfu/SwiftSoup", from: "2.3.2"),
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
     ],
     targets: [
         .target(
@@ -28,6 +28,9 @@ let package = Package(
                 "Info.plist",
                 // Support for ZIPFoundation is not yet achieved.
                 "Toolkit/Archive/ZIPFoundation.swift"
+            ],
+            resources: [
+                .process("Resources")
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -27,10 +27,14 @@ let package = Package(
             exclude: [
                 "Info.plist",
                 // Support for ZIPFoundation is not yet achieved.
-                "Toolkit/Archive/ZIPFoundation.swift"
+                "Toolkit/Archive/ZIPFoundation.swift",
             ],
             resources: [
-                .process("Resources")
+                .process("Resources"),
+            ],
+            linkerSettings: [
+                .linkedFramework("CoreServices"),
+                .linkedFramework("UIKit"),
             ]
         ),
         .testTarget(
@@ -39,8 +43,8 @@ let package = Package(
             path: "./r2-shared-swiftTests/",
             exclude: ["Info.plist"],
             resources: [
-                .copy("Fixtures")
+                .copy("Fixtures"),
             ]
-        )
+        ),
     ]
 )

--- a/r2-shared-swift.xcodeproj/project.pbxproj
+++ b/r2-shared-swift.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		CAF4EAE42237ABC700A17DA1 /* MediaOverlayNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E7D4041F4EC69100DF166D /* MediaOverlayNode.swift */; };
 		CAF4EAE52237ABC700A17DA1 /* MediaOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E7D4051F4EC69100DF166D /* MediaOverlays.swift */; };
 		CAF4EAE72237AD6000A17DA1 /* UserProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF39DF220E3895200A560F3 /* UserProperties.swift */; };
+		CAF6487B266E9A880067D2C3 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF6487A266E9A880067D2C3 /* Bundle.swift */; };
 		F3E7D3F91F4EBE2100DF166D /* r2-shared-swift.h in Headers */ = {isa = PBXBuildFile; fileRef = F3E7D3F71F4EBE2100DF166D /* r2-shared-swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F3E7D4191F4EC69100DF166D /* RootFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E7D40C1F4EC69100DF166D /* RootFile.swift */; };
 		F3E7D4231F4ECB3D00DF166D /* Date+ISO8601.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E7D4221F4ECB3D00DF166D /* Date+ISO8601.swift */; };
@@ -402,7 +403,8 @@
 		CAE4DCB124BB669D00611638 /* GeneratedCoverServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedCoverServiceTests.swift; sourceTree = "<group>"; };
 		CAE4DCB324BB6D9E00611638 /* CoverServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverServiceTests.swift; sourceTree = "<group>"; };
 		CAE4DCB524BB71FF00611638 /* Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
-		CAF21470264ABB9300056F52 /* SwiftSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = "SwiftSoup.framework"; sourceTree = "BUILT_PRODUCTS_DIR"; };
+		CAF21470264ABB9300056F52 /* SwiftSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAF6487A266E9A880067D2C3 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		F3B1879F1FA33D4D00BB46BF /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
 		F3B187A11FA33DFA00BB46BF /* Facet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Facet.swift; sourceTree = "<group>"; };
 		F3B187A31FA33E1D00BB46BF /* OpdsMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpdsMetadata.swift; sourceTree = "<group>"; };
@@ -830,6 +832,7 @@
 				CA1AB0C324E2D0EA00004BC0 /* URL.swift */,
 				3ED941F913B58D61AE98A6CC /* UInt64.swift */,
 				3ED942B2BBE9224BBDB9CDEE /* Collection.swift */,
+				CAF6487A266E9A880067D2C3 /* Bundle.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1250,6 +1253,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CABC49CE264582CF00375DEF /* SearchService.swift in Sources */,
+				CAF6487B266E9A880067D2C3 /* Bundle.swift in Sources */,
 				CA6D426B240439BE002FBED4 /* OPDSCopies.swift in Sources */,
 				CA17638D223A984600959FEB /* Publication.swift in Sources */,
 				F3E7D4231F4ECB3D00DF166D /* Date+ISO8601.swift in Sources */,

--- a/r2-shared-swift/Toolkit/Extensions/Bundle.swift
+++ b/r2-shared-swift/Toolkit/Extensions/Bundle.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+#if !SWIFT_PACKAGE
+extension Bundle {
+    static let module = Bundle(identifier: "org.readium.r2-shared-swift")!
+}
+#endif

--- a/r2-shared-swift/Toolkit/R2LocalizedString.swift
+++ b/r2-shared-swift/Toolkit/R2LocalizedString.swift
@@ -1,18 +1,22 @@
 //
-//  R2LocalizedString.swift
-//  r2-shared-swift
-//
-//  Created by Mickaël Menu on 13.06.19.
-//
-//  Copyright 2019 Readium Foundation. All rights reserved.
-//  Use of this source code is governed by a BSD-style license which is detailed
-//  in the LICENSE file present in the project repository where this source code is maintained.
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
 //
 
 import Foundation
 
-/// Returns the localized string in the main bundle, or fallback on the bundle with given ID if not found.
+/// Returns the localized string in the main bundle, or fallback on the given bundle if not found.
 /// Can be used to override framework localized strings in the host app.
+public func R2LocalizedString(_ key: String, in bundle: Bundle? = nil, _ values: [CVarArg]) -> String {
+    let defaultValue = (bundle ?? Bundle.module)?.localizedString(forKey: key, value: nil, table: nil)
+    var string = Bundle.main.localizedString(forKey: key, value: defaultValue, table: nil)
+    if !values.isEmpty {
+        string = String(format: string, locale: Locale.current, arguments: values)
+    }
+    return string
+}
+
 public func R2LocalizedString(_ key: String, in bundleID: String, _ values: [CVarArg]) -> String {
     let defaultValue = Bundle(identifier: bundleID)?.localizedString(forKey: key, value: nil, table: nil)
     var string = Bundle.main.localizedString(forKey: key, value: defaultValue, table: nil)
@@ -27,5 +31,5 @@ public func R2LocalizedString(_ key: String, in bundleID: String, _ values: CVar
 }
 
 func R2SharedLocalizedString(_ key: String, _ values: CVarArg...) -> String {
-    return R2LocalizedString("R2Shared.\(key)", in: "org.readium.r2-shared-swift", values)
+    return R2LocalizedString("R2Shared.\(key)", values)
 }

--- a/r2-shared-swiftTests/Asserts.swift
+++ b/r2-shared-swiftTests/Asserts.swift
@@ -12,6 +12,11 @@
 import XCTest
 
 func AssertJSONEqual(_ json1: Any, _ json2: Any, file: StaticString = #file, line: UInt = #line) {
+    guard #available(iOS 11.0, *) else {
+        XCTFail("iOS 11 is required to run JSON tests")
+        return
+    }
+    
     do {
         // Wrap the objects in an array to allow JSON fragments comparisons
         let d1 = String(data: try JSONSerialization.data(withJSONObject: [json1], options: .sortedKeys), encoding: .utf8)

--- a/r2-shared-swiftTests/Fixtures.swift
+++ b/r2-shared-swiftTests/Fixtures.swift
@@ -12,6 +12,12 @@
 import Foundation
 import XCTest
 
+#if !SWIFT_PACKAGE
+extension Bundle {
+    static let module = Bundle(for: Fixtures.self)
+}
+#endif
+
 class Fixtures {
     
     let path: String?
@@ -20,10 +26,8 @@ class Fixtures {
         self.path = path
     }
     
-    private lazy var bundle = Bundle(for: type(of: self))
-    
     func url(for filepath: String) -> URL {
-        return try! XCTUnwrap(bundle.resourceURL?.appendingPathComponent("Fixtures/\(path ?? "")/\(filepath)"))
+        return try! XCTUnwrap(Bundle.module.resourceURL?.appendingPathComponent("Fixtures/\(path ?? "")/\(filepath)"))
     }
     
     func data(at filepath: String) -> Data {

--- a/r2-shared-swiftTests/JSON.swift
+++ b/r2-shared-swiftTests/JSON.swift
@@ -8,8 +8,14 @@
 //
 
 import Foundation
+import XCTest
 
 func toJSON<T: Encodable>(_ object: T) -> String? {
+    guard #available(iOS 11.0, *) else {
+        XCTFail("iOS 11 is required to run JSON tests")
+        return nil
+    }
+    
     let jsonEncoder = JSONEncoder()
     jsonEncoder.outputFormatting.insert(.sortedKeys)
     guard let jsonData = try? jsonEncoder.encode(object),


### PR DESCRIPTION
Fixed embedding localized strings in the package.

I was able to run the unit tests with the following `test.xcconfig`:

```xcconfig
IPHONEOS_DEPLOYMENT_TARGET = 11.0
OTHER_LDFLAGS = $(inherited) -framework CoreServices
```

And the given commands:

```
rm -rf r2-shared-swift.xcodeproj
xcodebuild test -destination 'name=iPhone 11' -scheme 'r2-shared-swift' -xcconfig test.xcconfig
```