### PR TITLE
Fix Bundle.module fallback

### DIFF
--- a/r2-shared-swift/Toolkit/Extensions/Bundle.swift
+++ b/r2-shared-swift/Toolkit/Extensions/Bundle.swift
@@ -8,6 +8,7 @@ import Foundation
 
 #if !SWIFT_PACKAGE
 extension Bundle {
-    static let module = Bundle(identifier: "org.readium.r2-shared-swift")!
+    /// Returns R2Shared's bundle by querying an arbitrary type.
+    static let module = Bundle(for: Publication.self)
 }
 #endif


### PR DESCRIPTION
CocoaPods is overriding our modules' bundle IDs, so we can't hard-code them to get the `Bundle`.