### PR TITLE
Fix sniffing the media type of a RWPM larger than 100KB

### DIFF
--- a/r2-shared-swift/Toolkit/Media Type/MediaTypeSnifferContent.swift
+++ b/r2-shared-swift/Toolkit/Media Type/MediaTypeSnifferContent.swift
@@ -34,8 +34,8 @@ final class FileMediaTypeSnifferContent: MediaTypeSnifferContent, Loggable {
     }
     
     func read() -> Data? {
-        // We only read files smaller than 100KB to avoid going out of memory.
-        guard let length = length, length < 100000 else {
+        // We only read files smaller than 5MB to avoid going out of memory.
+        guard let length = length, length < 5 * 1000 * 1000 else {
             return nil
         }
         return try? Data(contentsOf: file)


### PR DESCRIPTION
Raises the maximum content length of sniffed content to 5MB. 100KB was too small, in the wild a RWPM can get larger than this.