### PR TITLE
Add UserProperties::removeProperty api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
         }
     }
     ```
+* New `UserProperties.removeProperty(forReference:)` API to remove unwanted Readium CSS properties (contributed by [@ettore](https://github.com/readium/r2-shared-swift/pull/157)).
 
 
 ## [2.0.1]

--- a/r2-shared-swift/Publication/User Settings/UserProperties.swift
+++ b/r2-shared-swift/Publication/User Settings/UserProperties.swift
@@ -123,4 +123,13 @@ public class UserProperties {
     public func getProperty(reference: String) -> UserProperty? {
         return properties.filter { $0.reference == reference }.first
     }
+
+    /// Removes a property matching a ReadiumCSS reference.
+    /// - Parameter ref: The CSS reference of the property to be removed.
+    public func removeProperty(forReference ref: ReadiumCSSReference) {
+        properties.removeAll {
+            $0.reference == ref.rawValue
+        }
+    }
+
 }


### PR DESCRIPTION
This makes the `UserProperties` api more complete, allowing client apps to remove property values they do not care for from the default lists set up by R2.  E.g. r2-navigator sets up a list of fontFamilies that not all apps may want to present to users.