### PR TITLE
Fallback on checking the doctype when sniffing HTML documents

### DIFF
--- a/r2-shared-swift/Toolkit/Media Type/MediaTypeSniffer.swift
+++ b/r2-shared-swift/Toolkit/Media Type/MediaTypeSniffer.swift
@@ -113,7 +113,10 @@ public extension MediaType {
         if context.hasFileExtension("htm", "html", "xht", "xhtml") || context.hasMediaType("text/html", "application/xhtml+xml") {
             return .html
         }
-        if context.contentAsXML?.documentElement?.localName.lowercased() == "html" {
+        if
+            context.contentAsXML?.documentElement?.localName.lowercased() == "html" ||
+            context.contentAsString?.trimmingCharacters(in: .whitespacesAndNewlines).prefix(15).lowercased() == "<!doctype html>"
+        {
             return .html
         }
         return nil

--- a/r2-shared-swiftTests/Fixtures/Format/html-doctype-case.unknown
+++ b/r2-shared-swiftTests/Fixtures/Format/html-doctype-case.unknown
@@ -1,0 +1,10 @@
+   <!doctype html>
+<html lang=en>
+  <head>
+    <title>sample HTML document</title>
+    <meta charset='utf-8'>
+  </head>
+  <body>
+    <p>Sample HTML document.</p>
+  </body>
+</html>

--- a/r2-shared-swiftTests/Toolkit/Media Type/MediaTypeSnifferTests.swift
+++ b/r2-shared-swiftTests/Toolkit/Media Type/MediaTypeSnifferTests.swift
@@ -113,6 +113,7 @@ class MediaTypeSnifferTests: XCTestCase {
         XCTAssertEqual(MediaType.of(mediaType: "text/html"), .html)
         XCTAssertEqual(MediaType.of(mediaType: "application/xhtml+xml"), .html)
         XCTAssertEqual(MediaType.of(fixtures.url(for: "html.unknown")), .html)
+        XCTAssertEqual(MediaType.of(fixtures.url(for: "html-doctype-case.unknown")), .html)
         XCTAssertEqual(MediaType.of(fixtures.url(for: "xhtml.unknown")), .html)
     }
     


### PR DESCRIPTION
`context.contentAsXML?.documentElement?.localName.lowercased() == "html"` fails when the doctype is case insensitive.