### PR TITLE
Improve performances of the `StringSearchService` with HTML resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       scheme: ${{ 'r2-shared-swift' }}
       platform: ${{ 'iOS Simulator' }}
+      device: ${{ 'iPhone 13' }}
 
     steps:
       - name: Checkout
@@ -30,9 +31,7 @@ jobs:
           rm -rf r2-shared-swift.xcodeproj
       - name: Build
         run: |
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
           xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device"
       - name: Test
         run: |
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
           xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project will be documented in this file.
 
 * Support for Paragraph Margins user setting.
 
+### Fixed
+
+* Improved performances of the search service used with EPUB.
+
+
 ## [2.1.0]
 
 ### Added

--- a/r2-shared-swift/Toolkit/XML/Fuzi.swift
+++ b/r2-shared-swift/Toolkit/XML/Fuzi.swift
@@ -18,6 +18,7 @@ final class FuziXMLDocument: XMLDocument, Loggable {
     
     init(string: String, namespaces: [XMLNamespace]) throws {
         self.document = try Fuzi.XMLDocument(string: string)
+        document.definePrefixes(namespaces)
     }
     
     lazy var documentElement: XMLElement? =


### PR DESCRIPTION
`StringSearchService` was sometimes performing very slowly on some HTML resources. The bottleneck was in the parsing from SwiftSoup (third-party dependency). To solve this, we now attempt to parse the resource as strict XML first and fallback on SwiftSoup only when the HTML resource is not a valid XML.

As EPUB resources are supposed to be valid XHTML, this improves performances of EPUB search.

### Fixed

* Improved performances of the search service used with EPUB.